### PR TITLE
[BG-5339] Refactor executable bundling experience for WRW

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Please see the [releases page](https://github.com/BitGo/wallet-recovery-wizard/r
 ```shell
 git clone git@github.com:BitGo/wallet-recovery-wizard.git # install the application
 cd wallet-recovery-wizard
+brew install openssl # required to compile native libraries
+ln -s /usr/local/opt/openssl/include/openssl /usr/local/include # required to compile native libraries
 npm install
 npm run start # run a development server and start the app
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Please see the [releases page](https://github.com/BitGo/wallet-recovery-wizard/r
 ```shell
 git clone git@github.com:BitGo/wallet-recovery-wizard.git # install the application
 cd wallet-recovery-wizard
-yarn install --ignore-engines # can also use npm
-yarn run dev # run a development server and start the app
+npm install
+npm run start # run a development server and start the app
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "NODE_ENV=development concurrently 'node scripts/start.js' 'node scripts/electron-wait-react'",
     "build-clean": "rm -rf ./build/*",
     "electron": "electron .",
+    "build": "NODE_ENV=production node scripts/build.js",
     "make": "NODE_ENV=production node scripts/build.js && electron-forge make -p 'darwin' && electron-forge make -p 'win32'"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "main": "src/main.js",
   "homepage": "./",
   "scripts": {
-    "start": "NODE_ENV=development electron-forge start",
-    "dev": "NODE_ENV=development electron-forge start",
+    "start": "NODE_ENV=development concurrently 'node scripts/start.js' 'node scripts/electron-wait-react'",
+    "dev": "NODE_ENV=development concurrently 'node scripts/start.js' 'node scripts/electron-wait-react'",
     "build-clean": "rm -rf ./build/*",
+    "electron": "electron .",
     "make": "NODE_ENV=production node scripts/build.js && electron-forge make -p 'darwin' && electron-forge make -p 'win32'"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,16 @@
 {
   "name": "BitGoWalletRecoveryWizard",
+  "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "main": "src/main.js",
   "homepage": "./",
   "scripts": {
-    "start": "node scripts/start.js",
-    "build-react": "node scripts/build.js",
-    "test": "node scripts/test.js --env=jsdom",
-    "dev": "NODE_ENV=development nf start",
-    "electron": "electron .",
-    "build-css": "node-sass-chokidar src/ -o src/",
-    "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
+    "start": "NODE_ENV=development electron-forge start",
+    "dev": "NODE_ENV=development electron-forge start",
     "build-clean": "rm -rf ./build/*",
-    "package": "node scripts/package.js",
-    "publish": "electron-forge publish --skip-package"
+    "make": "NODE_ENV=production node scripts/build.js && electron-forge make -p 'darwin' && electron-forge make -p 'win32'"
   },
   "dependencies": {
     "autoprefixer": "7.1.6",
@@ -28,10 +23,11 @@
     "chalk": "1.1.3",
     "classnames": "^2.2.5",
     "css-loader": "0.28.7",
-    "dns": "^0.2.2",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.0.1",
+    "electron-compile": "^6.4.2",
     "electron-localshortcut": "^3.1.0",
+    "electron-squirrel-startup": "^1.0.0",
     "eslint": "4.10.0",
     "eslint-config-react-app": "^2.1.0",
     "eslint-loader": "1.9.0",
@@ -46,23 +42,24 @@
     "file-loader": "1.1.5",
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
+    "jquery": "^1.9.1",
     "lodash": "^4.17.5",
     "moment": "^2.20.1",
+    "nan": "^2.10.0",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",
     "promise": "8.0.1",
     "prova-lib": "^0.2.9",
     "raf": "3.4.0",
-    "react": "^16.2.0",
-    "react-addons-css-transition-group": "^15.6.2",
+    "react": "^16.4.1",
     "react-dev-utils": "^5.0.0",
     "react-dom": "^16.2.0",
     "react-mailto": "^0.4.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "react-select": "^1.2.1",
-    "react-transition-group": "^2.2.1",
+    "react-transition-group": "^1.2.1",
     "reactstrap": "^5.0.0-beta",
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0",
@@ -86,20 +83,19 @@
     "babel-jest": "20.0.3",
     "babel-loader": "7.1.2",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
-    "babel-preset-env": "^1.6.1",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
-    "electron": "^1.8.4",
     "electron-compile": "^6.4.2",
-    "electron-forge": "^5.1.1",
-    "electron-prebuilt-compile": "1.8.2",
+    "electron-forge": "^5.2.2",
+    "electron-prebuilt-compile": "2.0.2",
     "electron-squirrel-startup": "^1.0.0",
-    "electron-winstaller": "^2.6.4",
     "electron-wix-msi": "^1.3.0",
     "foreman": "^2.0.0",
     "jest": "20.0.4",
-    "node-sass-chokidar": "^0.0.3"
+    "node-sass-chokidar": "^0.0.3",
+    "react": "^16.4.1"
   },
   "jest": {
     "collectCoverageFrom": [
@@ -150,6 +146,7 @@
           "squirrel"
         ],
         "darwin": [
+          "zip",
           "dmg"
         ],
         "linux": [
@@ -158,21 +155,21 @@
         ]
       },
       "electronPackagerConfig": {
-        "packageManager": "npm"
+        "packageManager": "npm",
+        "asar": true
       },
       "electronWinstallerConfig": {
-        "name": "wallet_recovery_wizard",
-        "authors": "Kevin Kennis <kevin@bitgo.com>"
+        "name": "BitGoWalletRecoveryWizard"
       },
       "electronInstallerDebian": {},
       "electronInstallerRedhat": {},
       "github_repository": {
-        "owner": "BitGo",
-        "name": "wallet-recovery-wizard"
+        "owner": "",
+        "name": ""
       },
       "windowsStoreConfig": {
         "packageName": "",
-        "name": "walletrecoverywizard"
+        "name": "BitGoWalletRecoveryWizard"
       }
     }
   }

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router-dom';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import CSSTransitionGroup  from 'react-transition-group/CSSTransitionGroup';
 import classNames from 'classnames';
 import nav from 'constants/nav';
 
@@ -12,7 +12,7 @@ const Sidebar = withRouter(({ isLoggedIn, location }) => {
   const showSidebar = location.pathname !== '/' && !location.pathname.match(/index\.html$/) && isLoggedIn;
 
   return (
-    <ReactCSSTransitionGroup
+    <CSSTransitionGroup
       transitionName='slide'
       transitionEnterTimeout={500}
       transitionLeaveTimeout={300}
@@ -26,7 +26,7 @@ const Sidebar = withRouter(({ isLoggedIn, location }) => {
           )}
         </div>
       }
-    </ReactCSSTransitionGroup>
+    </CSSTransitionGroup>
   );
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ function createWindow() {
 
     mainWindow.loadURL(startUrl);
     // Open the DevTools.
-    mainWindow.webContents.openDevTools();
+    // mainWindow.webContents.openDevTools();
 
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ function createWindow() {
 
     mainWindow.loadURL(startUrl);
     // Open the DevTools.
-    // mainWindow.webContents.openDevTools();
+    mainWindow.webContents.openDevTools();
 
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 


### PR DESCRIPTION
Modifies package.json to use electron-forge dependencies and node scripts. Bumps version to 1.1.0. Removes unused package (dns) which was causing conflicts with forge, and replaces react-addons-css-transition-group with react-transition-group/CSSTransitionGroup.