### PR TITLE
[BG-5438] Add XRP support to WRW

### DIFF
--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -12,7 +12,7 @@ const formTooltips = tooltips.recovery;
 
 class NonBitGoRecoveryForm extends Component {
   state = {
-    coin: 'eth',
+    coin: 'btc',
     userKey: '',
     backupKey: '',
     bitgoKey: '',
@@ -104,6 +104,7 @@ class NonBitGoRecoveryForm extends Component {
       userKey: '',
       backupKey: '',
       walletContractAddress: '',
+      rootAddress: '',
       tokenAddress: '',
       walletPassphrase: '',
       recoveryDestination: '',

--- a/src/constants/coin-config.js
+++ b/src/constants/coin-config.js
@@ -48,6 +48,7 @@ export default {
       icon: xrpIcon,
       envOptions: [
         { label: 'Mainnet', value: 'prod' },
+        { label: 'Testnet', value: 'test' }
       ]
     },
     eth: {
@@ -107,6 +108,6 @@ export default {
   },
   supportedRecoveries: {
     crossChain: ['btc', 'bch', 'ltc'],
-    nonBitGo: ['eth', 'btc', 'ltc', 'bch', 'btg', 'token']
+    nonBitGo: ['btc', 'eth', 'xrp', 'bch', 'ltc', 'btg', 'token']
   }
 }


### PR DESCRIPTION
Added XRP to non-BitGo recoveries.

NB this will not work in dev mode, as dev mode hosts a local server which violates a CORS policy on the rippled server. To test, run `npm run make` and run the compiled DMG.