### PR TITLE
[BG-5604] Add batching to cross-chain recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jquery": "^3.3.1",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
+    "jszip": "^3.1.5",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "^3.3.1",
     "postcss-loader": "^2.1.5",

--- a/src/components/cross-chain.js
+++ b/src/components/cross-chain.js
@@ -100,6 +100,14 @@ class CrossChainRecoveryForm extends Component {
     });
   }
 
+  getFileName = (index) => {
+    if (this.state.signed) {
+      return `${this.state.recoveryTxs[index].sourceCoin}r-${this.state.txids[index].slice(0, 6)}-${moment().format('YYYYMMDD')}.signed.json`;
+    } else {
+      return `${this.state.recoveryTxs[index].coin}r-${this.state.txids[index].slice(0, 6)}-${moment().format('YYYYMMDD')}.unsigned.json`;
+    }
+  }
+
   performRecovery = async () => {
     const { bitgo } = this.props;
     const {
@@ -149,13 +157,7 @@ class CrossChainRecoveryForm extends Component {
   saveSingleTransaction = async () => {
     const transaction = this.state.recoveryTxs[0];
 
-    let fileName;
-
-    if (this.state.signed) {
-      fileName = `${transaction.sourceCoin}r-${this.state.txids[0].slice(0, 6)}-${moment().format('YYYYMMDD')}.signed.json`;
-    } else {
-      fileName = `${transaction.coin}r-${this.state.txids[0].slice(0, 6)}-${moment().format('YYYYMMDD')}.unsigned.json`;
-    }
+    let fileName = this.getFileName(0);
 
     const dialogParams = {
       filters: [{
@@ -185,13 +187,7 @@ class CrossChainRecoveryForm extends Component {
     const zip = new jszip();
 
     _.forEach(transactions, (transaction, index) => {
-      let fileName;
-
-      if (this.state.signed) {
-        fileName = `${transaction.sourceCoin}r-${this.state.txids[index].slice(0, 6)}-${moment().format('YYYYMMDD')}.signed.json`;
-      } else {
-        fileName = `${transaction.coin}r-${this.state.txids[index].slice(0, 6)}-${moment().format('YYYYMMDD')}.unsigned.json`;
-      }
+      let fileName = this.getFileName(index);
 
       zip.file(fileName, JSON.stringify(transaction, null, 4));
     })
@@ -255,12 +251,14 @@ class CrossChainRecoveryForm extends Component {
         {(this.state.recoveryTxs.length > 0 && this.state.signed) &&
         <ConfirmTxSigned txDetails={this.state.recoveryTxs}
                          error={this.state.error}
+                         bitgo={this.props.bitgo}
                          saveTransactions={this.saveTransactions}
                          resetRecovery={this.resetRecovery} />
         }
         {(this.state.recoveryTxs.length > 0 && !this.state.signed) &&
         <ConfirmTxUnsigned txDetails={this.state.recoveryTxs}
                            error={this.state.error}
+                           bitgo={this.props.bitgo}
                            saveTransactions={this.saveTransactions}
                            resetRecovery={this.resetRecovery}/>
         }
@@ -376,11 +374,10 @@ class RecoveryTxForm extends Component {
 
 class ConfirmTxSigned extends Component {
   render() {
-    const { txDetails, error } = this.props;
+    const { txDetails, error, bitgo } = this.props;
     let recoveryAmount = 0;
 
     for (const tx of txDetails) {
-      console.log(tx.recoveryAmount);
       recoveryAmount += tx.recoveryAmount;
     }
 
@@ -388,11 +385,11 @@ class ConfirmTxSigned extends Component {
       <div>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Source Coin:</Col>
-          <Col xs={5}>{coinConfig.allCoins[txDetails[0].sourceCoin].fullName} ({txDetails[0].sourceCoin.toUpperCase()})</Col>
+          <Col xs={5}>{bitgo.coin(txDetails[0].sourceCoin).getFullName()} ({txDetails[0].sourceCoin.toUpperCase()})</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Recovery Coin:</Col>
-          <Col xs={5}>{coinConfig.allCoins[txDetails[0].recoveryCoin].fullName} ({txDetails[0].recoveryCoin.toUpperCase()})</Col>
+          <Col xs={5}>{bitgo.coin(txDetails[0].recoveryCoin).getFullName()} ({txDetails[0].recoveryCoin.toUpperCase()})</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Wallet:</Col>
@@ -424,7 +421,7 @@ class ConfirmTxSigned extends Component {
 
 class ConfirmTxUnsigned extends Component {
   render() {
-    const { txDetails, error } = this.props;
+    const { txDetails, error, bitgo } = this.props;
     let recoveryAmount = 0;
 
     for (const tx of txDetails) {
@@ -435,7 +432,7 @@ class ConfirmTxUnsigned extends Component {
       <div>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Source Coin:</Col>
-          <Col xs={5}>{coinConfig.allCoins[txDetails[0].coin].fullName} ({txDetails.coin.toUpperCase()})</Col>
+          <Col xs={5}>{bitgo.coin(txDetails[0].coin).getFullName()} ({txDetails.coin.toUpperCase()})</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Wallet:</Col>

--- a/src/components/cross-chain.js
+++ b/src/components/cross-chain.js
@@ -2,7 +2,8 @@ import React, { Component, Fragment } from 'react';
 
 import {
   CoinDropdown,
-  InputField
+  InputField,
+  MultiInputField
 } from './form-components';
 
 import ErrorMessage from './error-message';
@@ -20,6 +21,8 @@ import tooltips from 'constants/tooltips';
 import coinConfig from 'constants/coin-config';
 
 import moment from 'moment';
+import jszip from 'jszip';
+import * as _ from 'lodash';
 
 const fs = window.require('fs');
 const { dialog } = window.require('electron').remote;
@@ -30,14 +33,14 @@ class CrossChainRecoveryForm extends Component {
     sourceCoin: 'btc',
     recoveryCoin: 'ltc',
     wallet: '',
-    txid: '',
+    txids: [''],
     unspent: '',
     address: '',
     signed: true,
     recoveryAddress: '',
     passphrase: '',
     prv: '',
-    recoveryTx: null,
+    recoveryTxs: [],
     logging: ['']
   }
 
@@ -61,19 +64,37 @@ class CrossChainRecoveryForm extends Component {
     }
   }
 
+  updateTxids = (index) => (value) => {
+    const txids = this.state.txids;
+    txids[index] = value;
+    this.setState({ txids });
+  }
+
+  addBlankTxid = () => {
+    const txids = this.state.txids;
+    txids.push('');
+    this.setState({ txids });
+  }
+
+  removeTxid = (index) => () => {
+    const txids = this.state.txids;
+    txids.splice(index, 1);
+    this.setState({ txids });
+  }
+
   resetRecovery = () => {
     this.setState({
       sourceCoin: 'btc',
       recoveryCoin: 'ltc',
       wallet: '',
-      txid: '',
+      txids: [''],
       unspent: '',
       address: '',
       recoveryAddress: '',
       signed: true,
       passphrase: '',
       prv: '',
-      recoveryTx: null,
+      recoveryTxs: [],
       logging: [''],
       error: ''
     });
@@ -83,7 +104,7 @@ class CrossChainRecoveryForm extends Component {
     const { bitgo } = this.props;
     const {
       wallet,
-      txid,
+      txids,
       recoveryAddress,
       signed,
       passphrase,
@@ -95,32 +116,45 @@ class CrossChainRecoveryForm extends Component {
 
     this.setState({ error: '' });
 
-    try {
-      const recoveryTx = await bitgo.coin(sourceCoin).recoverFromWrongChain({
-        txid: txid,
-        recoveryAddress: recoveryAddress,
-        wallet: wallet,
-        coin: bitgo.coin(recoveryCoin),
-        signed: signed,
-        walletPassphrase: passphrase,
-        xprv: prv
-      });
+    const basecoin = bitgo.coin(sourceCoin);
 
-      this.setState({ recoveryTx: recoveryTx });
-    } catch (e) {
-      this.collectLog(e.message);
-      this.setState({ error: e.message });
+    for (const txid of txids) {
+      try {
+        const recoveryTx = await basecoin.recoverFromWrongChain({
+          txid: txid,
+          recoveryAddress: recoveryAddress,
+          wallet: wallet,
+          coin: bitgo.coin(recoveryCoin),
+          signed: signed,
+          walletPassphrase: passphrase,
+          xprv: prv
+        });
+
+        let recoveryTxs = this.state.recoveryTxs;
+        recoveryTxs.push(recoveryTx);
+
+        // it's possible to have duplicate transactions if multiple wrong chain txs were on the same address. let's not
+        // give support any more recoveries than they need :)
+        recoveryTxs = _.uniqBy(recoveryTxs, 'txHex');
+
+        this.setState({ recoveryTxs });
+      } catch (e) {
+        const err = `${e.message}`;
+        this.collectLog(err);
+        this.setState({ error: err })
+      }
     }
   }
 
-  saveTransaction = () => {
-    const fileData = this.state.recoveryTx;
+  saveSingleTransaction = async () => {
+    const transaction = this.state.recoveryTxs[0];
+
     let fileName;
 
     if (this.state.signed) {
-      fileName = `${fileData.sourceCoin}r-${this.state.txid.slice(0, 6)}-${moment().format('YYYYMMDD')}.signed.json`;
+      fileName = `${transaction.sourceCoin}r-${this.state.txids[0].slice(0, 6)}-${moment().format('YYYYMMDD')}.signed.json`;
     } else {
-      fileName = `${fileData.coin}r-${this.state.txid.slice(0, 6)}-${moment().format('YYYYMMDD')}.unsigned.json`;
+      fileName = `${transaction.coin}r-${this.state.txids[0].slice(0, 6)}-${moment().format('YYYYMMDD')}.unsigned.json`;
     }
 
     const dialogParams = {
@@ -131,7 +165,6 @@ class CrossChainRecoveryForm extends Component {
       defaultPath: '~/' + fileName
     };
 
-    // Retrieve the desired file path and file name
     const filePath = dialog.showSaveDialog(dialogParams);
     if (!filePath) {
       // TODO: The user exited the file creation process. What do we do?
@@ -139,10 +172,59 @@ class CrossChainRecoveryForm extends Component {
     }
 
     try {
-      fs.writeFileSync(filePath, JSON.stringify(fileData, null, 4), 'utf8');
+      fs.writeFileSync(filePath, JSON.stringify(transaction, null, 4), 'utf8');
     } catch (err) {
       console.log('error saving', err);
       this.setState({ error: 'There was a problem saving your recovery file. Please try again.' });
+    }
+  }
+
+  saveMultipleTransactions = async () => {
+    const transactions = this.state.recoveryTxs;
+
+    const zip = new jszip();
+
+    _.forEach(transactions, (transaction, index) => {
+      let fileName;
+
+      if (this.state.signed) {
+        fileName = `${transaction.sourceCoin}r-${this.state.txids[index].slice(0, 6)}-${moment().format('YYYYMMDD')}.signed.json`;
+      } else {
+        fileName = `${transaction.coin}r-${this.state.txids[index].slice(0, 6)}-${moment().format('YYYYMMDD')}.unsigned.json`;
+      }
+
+      zip.file(fileName, JSON.stringify(transaction, null, 4));
+    })
+
+    const zipName = `${this.state.sourceCoin}-recoveries-${this.state.wallet.slice(0,6)}`;
+
+    const dialogParams = {
+      filters: [{
+        name: 'Custom File Type',
+        extensions: ['zip']
+      }],
+      defaultPath: '~/' + zipName
+    };
+
+    const filePath = dialog.showSaveDialog(dialogParams);
+    if (!filePath) {
+      // TODO: The user exited the file creation process. What do we do?
+      return;
+    }
+
+    try {
+      await zip.generateNodeStream({ type: 'nodebuffer', streamFiles: true }).pipe(fs.createWriteStream(filePath));
+    } catch (err) {
+      console.log('error saving', err);
+      this.setState({ error: 'There was a problem saving your recovery file. Please try again.' });
+    }
+  }
+
+  saveTransactions = async () => {
+    if (this.state.recoveryTxs.length === 1) {
+      await this.saveSingleTransaction();
+    } else {
+      await this.saveMultipleTransactions();
     }
   }
 
@@ -158,25 +240,28 @@ class CrossChainRecoveryForm extends Component {
         <h1 className='content-header'>Wrong Chain Recoveries</h1>
         <p className='subtitle'>This tool will help you construct a transaction to recover coins sent to addresses on the wrong chain.</p>
         <hr />
-        {this.state.recoveryTx === null &&
+        {this.state.recoveryTxs.length === 0 &&
         <RecoveryTxForm formState={this.state}
                         bitgo={this.props.bitgo}
                         updateRecoveryInfo={this.updateRecoveryInfo}
                         updateCheckbox={this.updateCheckbox}
                         updateSelect={this.updateSelect}
+                        updateTxids={this.updateTxids}
+                        addBlankTxid={this.addBlankTxid}
+                        removeTxid={this.removeTxid}
                         performRecovery={this.performRecovery}
                         resetRecovery={this.resetRecovery} />
         }
-        {(this.state.recoveryTx !== null && this.state.signed) &&
-        <ConfirmTxSigned txDetails={this.state.recoveryTx}
+        {(this.state.recoveryTxs.length > 0 && this.state.signed) &&
+        <ConfirmTxSigned txDetails={this.state.recoveryTxs}
                          error={this.state.error}
-                         saveTransaction={this.saveTransaction}
+                         saveTransactions={this.saveTransactions}
                          resetRecovery={this.resetRecovery} />
         }
-        {(this.state.recoveryTx !== null && !this.state.signed) &&
-        <ConfirmTxUnsigned txDetails={this.state.recoveryTx}
+        {(this.state.recoveryTxs.length > 0 && !this.state.signed) &&
+        <ConfirmTxUnsigned txDetails={this.state.recoveryTxs}
                            error={this.state.error}
-                           saveTransaction={this.saveTransaction}
+                           saveTransactions={this.saveTransactions}
                            resetRecovery={this.resetRecovery}/>
         }
       </div>
@@ -186,7 +271,7 @@ class CrossChainRecoveryForm extends Component {
 
 class RecoveryTxForm extends Component {
   render() {
-    const { formState, bitgo, updateRecoveryInfo, updateCheckbox, updateSelect, performRecovery, resetRecovery } = this.props;
+    const { formState, bitgo, updateRecoveryInfo, updateCheckbox, updateSelect, updateTxids, addBlankTxid, removeTxid, performRecovery, resetRecovery } = this.props;
     const { sourceCoin, recoveryCoin, logging, error } = formState;
     const allCoins = coinConfig.supportedRecoveries.crossChain;
     const recoveryCoins = coinConfig.allCoins[sourceCoin].supportedRecoveries;
@@ -230,11 +315,13 @@ class RecoveryTxForm extends Component {
             tooltipText={formTooltips.wallet(formState.recoveryCoin)}
             disallowWhiteSpace={true}
           />
-          <InputField
-            label='Transaction ID'
-            name='txid'
-            value={formState.txid}
-            onChange={updateRecoveryInfo}
+          <MultiInputField
+            label='Transaction IDs'
+            name='txids'
+            values={formState.txids}
+            onChange={updateTxids}
+            addField={addBlankTxid}
+            removeField={removeTxid}
             tooltipText={formTooltips.txid(formState.sourceCoin)}
             disallowWhiteSpace={true}
           />
@@ -290,33 +377,39 @@ class RecoveryTxForm extends Component {
 class ConfirmTxSigned extends Component {
   render() {
     const { txDetails, error } = this.props;
+    let recoveryAmount = 0;
+
+    for (const tx of txDetails) {
+      console.log(tx.recoveryAmount);
+      recoveryAmount += tx.recoveryAmount;
+    }
 
     return (
       <div>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Source Coin:</Col>
-          <Col xs={5}>{coinConfig.allCoins[txDetails.sourceCoin].fullName} ({txDetails.sourceCoin.toUpperCase()})</Col>
+          <Col xs={5}>{coinConfig.allCoins[txDetails[0].sourceCoin].fullName} ({txDetails[0].sourceCoin.toUpperCase()})</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Recovery Coin:</Col>
-          <Col xs={5}>{coinConfig.allCoins[txDetails.recoveryCoin].fullName} ({txDetails.recoveryCoin.toUpperCase()})</Col>
+          <Col xs={5}>{coinConfig.allCoins[txDetails[0].recoveryCoin].fullName} ({txDetails[0].recoveryCoin.toUpperCase()})</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Wallet:</Col>
-          <Col xs={5}>{txDetails.walletId}</Col>
+          <Col xs={5}>{txDetails[0].walletId}</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Amount to Recover:</Col>
-          <Col xs={5}>{txDetails.recoveryAmount * 1e-8} {txDetails.sourceCoin.toUpperCase()}</Col>
+          <Col xs={5}>{recoveryAmount * 1e-8} {txDetails[0].sourceCoin.toUpperCase()}</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Destination Address:</Col>
-          <Col xs={5}>{txDetails.recoveryAddress}</Col>
+          <Col xs={5}>{txDetails[0].recoveryAddress}</Col>
         </Row>
         {error && <ErrorMessage>{error}</ErrorMessage>}
         <Row>
           <Col xs={12}>
-            <Button onClick={this.props.saveTransaction} className='bitgo-button'>
+            <Button onClick={this.props.saveTransactions} className='bitgo-button'>
               Save Recovery Transaction
             </Button>
             <Button onClick={this.props.resetRecovery} className='bitgo-button other'>
@@ -332,29 +425,34 @@ class ConfirmTxSigned extends Component {
 class ConfirmTxUnsigned extends Component {
   render() {
     const { txDetails, error } = this.props;
+    let recoveryAmount = 0;
+
+    for (const tx of txDetails) {
+      recoveryAmount += tx.amount;
+    }
 
     return (
       <div>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Source Coin:</Col>
-          <Col xs={5}>{coinConfig.allCoins[txDetails.coin].fullName} ({txDetails.coin.toUpperCase()})</Col>
+          <Col xs={5}>{coinConfig.allCoins[txDetails[0].coin].fullName} ({txDetails.coin.toUpperCase()})</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Wallet:</Col>
-          <Col xs={5}>{txDetails.walletId}</Col>
+          <Col xs={5}>{txDetails[0].walletId}</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Amount to Recover:</Col>
-          <Col xs={5}>{txDetails.amount * 1e-8} {txDetails.coin.toUpperCase()}</Col>
+          <Col xs={5}>{recoveryAmount * 1e-8} {txDetails[0].coin.toUpperCase()}</Col>
         </Row>
         <Row>
           <Col xs={3} className='confirm-tx-field'>Destination Address:</Col>
-          <Col xs={5}>{txDetails.address}</Col>
+          <Col xs={5}>{txDetails[0].address}</Col>
         </Row>
         {error && <ErrorMessage>{error}</ErrorMessage>}
         <Row>
           <Col xs={12}>
-            <Button onClick={this.props.saveTransaction} className='bitgo-button'>
+            <Button onClick={this.props.saveTransactions} className='bitgo-button'>
               Save Recovery Transaction
             </Button>
             <Button onClick={this.props.resetRecovery} className='bitgo-button other'>

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -4,10 +4,13 @@ import coinConfig from '../constants/coin-config';
 import Select from 'react-select';
 
 import {
+  Button,
   Input,
   UncontrolledTooltip,
   FormGroup,
   FormFeedback,
+  InputGroup,
+  InputGroupAddon,
   Label
 } from 'reactstrap';
 
@@ -222,6 +225,61 @@ export class InputTextarea extends Component {
       </FormGroup>
     );
   }
+}
+
+export const MultiInputField = ({ label, name, values, onChange, addField, removeField, tooltipText, disallowWhiteSpace }) => {
+  const buttonCssFix = {
+    marginTop: 0,
+    padding: '0 12 0 12',
+    height: 38,
+    width: 38
+  };
+
+  const buttonPadding = {
+    marginTop: 4
+  }
+
+  const trim = (index) => (event) => {
+    let input = event.target.value;
+
+    if (disallowWhiteSpace) {
+      input = input.replace(/\s/g, '');
+    }
+
+    onChange(index)(input);
+  }
+
+  const inputFields = values.map((value, index) =>
+    <InputGroup key={index.toString()} style={index !== 0 ? buttonPadding : null}>
+      <Input
+        type='text'
+        onChange={trim(index)}
+        value={values[index]}
+      />
+      {index === 0 &&
+        <InputGroupAddon addonType='append'>
+          <Button onClick={addField} style={buttonCssFix}><b>+</b></Button>
+        </InputGroupAddon>
+      }
+      {index > 0 &&
+        <InputGroupAddon addonType='append'>
+          <Button onClick={removeField(index)} style={buttonCssFix}>{'\u2715'}</Button>
+        </InputGroupAddon>
+      }
+    </InputGroup>
+  );
+
+  return (
+    <FormGroup>
+      {label &&
+        <Label className='input-label'>
+          {label}
+          {tooltipText && <FieldTooltip name={name} text={tooltipText}/>}
+        </Label>
+      }
+      {inputFields}
+    </FormGroup>
+  );
 }
 
 const FieldTooltip = ({ name, text }) => (

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -3,7 +3,7 @@ export default {
     sourceCoin: () => 'This is the coin that was sent to the wrong address. For instance, if you sent BTC to an LTC address, the source coin would be BTC.',
     destinationCoin: () => 'This is the coin type of the wallet that received the source coin. For instance, if you sent BTC to an LTC address, the destination coin would be LTC.',
     wallet: (coin) => `This is the wallet ID of the wallet that received the source coin. This should be a ${coin.toUpperCase()} wallet.`,
-    txid: (coin) => `The transaction ID of the transaction that sent ${coin.toUpperCase()} to the wrong address.`,
+    txid: (coin) => `The transaction IDs of the transactions that sent ${coin.toUpperCase()} to the wrong address.`,
     address: (coin) => `The address the source coin was mistakenly sent to. This should be a ${coin.toUpperCase()} address.`,
     unspent: (coin) => `The unspent ID of the lost ${coin.toUpperCase()}, in the form [PREVIOUS_TX_ID]:[N_OUTPUT].`,
     recoveryAddress: (coin) => `The address your recovery transaction will send to. This should be a ${coin.toUpperCase()} address.`,


### PR DESCRIPTION
Adds a + button next to the txid field to add multiple txids. Multiple txids can be added or removed. If multiple transactions are needed, recovery transactions are saved in a zip file using jszip.