### PR TITLE
[BG-5603] Realtime input validation

### DIFF
--- a/src/components/cross-chain.js
+++ b/src/components/cross-chain.js
@@ -41,8 +41,8 @@ class CrossChainRecoveryForm extends Component {
     logging: ['']
   }
 
-  updateRecoveryInfo = (fieldName) => (event) => {
-    this.setState({ [fieldName]: event.target.value });
+  updateRecoveryInfo = (field) => (value) => {
+    this.setState({ [field]: value });
   }
 
   updateCheckbox = (fieldName) => (option) => {
@@ -224,30 +224,33 @@ class RecoveryTxForm extends Component {
           <InputField
             label='Wallet ID'
             name='wallet'
-            onChange={updateRecoveryInfo('wallet')}
             value={formState.wallet}
+            onChange={updateRecoveryInfo}
             tooltipText={formTooltips.wallet(formState.recoveryCoin)}
+            disallowWhiteSpace={true}
           />
           <InputField
             label='Transaction ID'
             name='txid'
-            onChange={updateRecoveryInfo('txid')}
             value={formState.txid}
+            onChange={updateRecoveryInfo}
             tooltipText={formTooltips.txid(formState.sourceCoin)}
+            disallowWhiteSpace={true}
           />
           <InputField
             label='Destination Address'
             name='recoveryAddress'
-            onChange={updateRecoveryInfo('recoveryAddress')}
             value={formState.recoveryAddress}
+            onChange={updateRecoveryInfo}
             tooltipText={formTooltips.recoveryAddress(formState.sourceCoin)}
+            disallowWhiteSpace={true}
           />
           {formState.signed &&
           <InputField
             label='Wallet Passphrase'
             name='passphrase'
-            onChange={updateRecoveryInfo('passphrase')}
             value={formState.passphrase}
+            onChange={updateRecoveryInfo}
             tooltipText={formTooltips.passphrase(formState.recoveryCoin)}
             isPassword={true}
           />
@@ -256,10 +259,11 @@ class RecoveryTxForm extends Component {
           <InputField
             label='Private Key'
             name='prv'
-            onChange={updateRecoveryInfo('prv')}
             value={formState.prv}
+            onChange={updateRecoveryInfo}
             tooltipText={formTooltips.prv(formState.recoveryCoin)}
             isPassword={true}
+            disallowWhiteSpace={true}
             />
           }
         </Fragment>

--- a/src/components/cross-chain.js
+++ b/src/components/cross-chain.js
@@ -160,6 +160,7 @@ class CrossChainRecoveryForm extends Component {
         <hr />
         {this.state.recoveryTx === null &&
         <RecoveryTxForm formState={this.state}
+                        bitgo={this.props.bitgo}
                         updateRecoveryInfo={this.updateRecoveryInfo}
                         updateCheckbox={this.updateCheckbox}
                         updateSelect={this.updateSelect}
@@ -185,7 +186,7 @@ class CrossChainRecoveryForm extends Component {
 
 class RecoveryTxForm extends Component {
   render() {
-    const { formState, updateRecoveryInfo, updateCheckbox, updateSelect, performRecovery, resetRecovery } = this.props;
+    const { formState, bitgo, updateRecoveryInfo, updateCheckbox, updateSelect, performRecovery, resetRecovery } = this.props;
     const { sourceCoin, recoveryCoin, logging, error } = formState;
     const allCoins = coinConfig.supportedRecoveries.crossChain;
     const recoveryCoins = coinConfig.allCoins[sourceCoin].supportedRecoveries;
@@ -244,6 +245,8 @@ class RecoveryTxForm extends Component {
             onChange={updateRecoveryInfo}
             tooltipText={formTooltips.recoveryAddress(formState.sourceCoin)}
             disallowWhiteSpace={true}
+            format='address'
+            coin={bitgo.coin(formState.sourceCoin)}
           />
           {formState.signed &&
           <InputField

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -89,7 +89,7 @@ export class InputField extends Component {
   }
 
   validate = () => {
-    const { value, format } = this.props;
+    const { value, format, coin } = this.props;
 
     if (value === '') {
       return;
@@ -113,6 +113,16 @@ export class InputField extends Component {
         this.setState({ error: null });
       } else {
         this.setState({ error: 'This field cannot be negative.' });
+      }
+    } else if (format === 'address') {
+      if (!coin) {
+        return;
+      }
+
+      if (coin.isValidAddress(value)) {
+        this.setState({ error: null });
+      } else {
+        this.setState({ error: `This should be a valid ${coin.getFamily().toUpperCase()} address.`});
       }
     }
   }

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -7,6 +7,7 @@ import {
   Input,
   UncontrolledTooltip,
   FormGroup,
+  FormFeedback,
   Label
 } from 'reactstrap';
 
@@ -69,38 +70,120 @@ const CoinDropdownValue = ({ value }) => (
   </span>
 );
 
-export const InputField = ({ label, name, value, onChange, tooltipText, isPassword }) => (
-  <FormGroup>
-    {label &&
-      <Label className='input-label'>
-        {label}
-        {tooltipText && <FieldTooltip name={name} text={tooltipText} />}
-      </Label>
-    }
-    <Input
-      type={isPassword ? 'password' : 'text'}
-      onChange={onChange}
-      value={value}
-    />
-  </FormGroup>
-);
+export class InputField extends Component {
+  state = {
+    error: null
+  };
 
-export const InputTextarea = ({ label, name, value, onChange, tooltipText }) => (
-  <FormGroup>
-    {label &&
-      <Label className='input-label'>
-        {label}
-        {tooltipText && <FieldTooltip name={name} text={tooltipText} />}
-      </Label>
+  trim = (event) => {
+    const { name, onChange, disallowWhiteSpace } = this.props;
+    let input = event.target.value;
+
+    if (disallowWhiteSpace) {
+      input = input.replace(/\s/g, '');
     }
-    <Input
-      type='textarea'
-      onChange={onChange}
-      value={value}
-      rows={4}
-    />
-  </FormGroup>
-);
+
+    onChange(name)(input);
+  }
+
+  validate = () => {
+    const { value, format } = this.props;
+    if (format === 'json') {
+      try {
+        JSON.parse(value);
+        this.setState({ error: null });
+      } catch (e) {
+        this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }' });
+      }
+    }
+  }
+
+  render() {
+    const { label, name, value, tooltipText, isPassword, format } = this.props;
+
+    let type = 'text';
+
+    if (isPassword) {
+      type = 'password';
+    } else if (format === 'number') {
+      type = 'number';
+    }
+
+    return (
+      <FormGroup>
+        {label &&
+        <Label className='input-label'>
+          {label}
+          {tooltipText && <FieldTooltip name={name} text={tooltipText}/>}
+        </Label>
+        }
+        <Input
+          type={type}
+          onChange={this.trim}
+          onBlur={this.validate}
+          value={value}
+          invalid={this.state.error !== null}
+        />
+        <FormFeedback>{this.state.error}</FormFeedback>
+      </FormGroup>
+    )
+  }
+}
+
+export class InputTextarea extends Component {
+  state = {
+    error: null
+  };
+
+  trim = (event) => {
+    const { name, disallowWhiteSpace, onChange } = this.props;
+    let input = event.target.value;
+
+    if (disallowWhiteSpace) {
+      input = input.replace(/\s/g, '');
+    }
+
+    onChange(name)(input);
+  }
+
+  validate = () => {
+    const { value, format } = this.props;
+
+    if (format === 'json') {
+      try {
+        JSON.parse(value);
+        this.setState({ error: null });
+      } catch (e) {
+        console.log(`${value} failed`)
+        this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }'});
+      }
+    }
+  }
+
+  render() {
+    const { label, name, value, tooltipText } = this.props;
+
+    return (
+      <FormGroup>
+        {label &&
+        <Label className='input-label'>
+          {label}
+          {tooltipText && <FieldTooltip name={name} text={tooltipText}/>}
+        </Label>
+        }
+        <Input
+          type='textarea'
+          onChange={this.trim}
+          onBlur={this.validate}
+          value={value}
+          rows={4}
+          invalid={this.state.error !== null}
+        />
+        <FormFeedback>{this.state.error}</FormFeedback>
+      </FormGroup>
+    );
+  }
+}
 
 const FieldTooltip = ({ name, text }) => (
   <span>

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -13,6 +13,8 @@ import {
 
 import questionMarkIcon from 'images/question_mark.png';
 
+const XPUB_LENGTH = 111; // string length of a base58-encoded xpub
+
 export const CoinDropdown = ({ label, name, value, allowedCoins, onChange, tooltipText }) => {
   const options = allowedCoins.map((coin) => ({
     value: coin,
@@ -100,6 +102,12 @@ export class InputField extends Component {
       } catch (e) {
         this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }' });
       }
+    } else if (format === 'xpub') {
+      if (value.startsWith('xpub') && value.length === XPUB_LENGTH) {
+        this.setState({ error: null });
+      } else {
+        this.setState({ error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
+      }
     }
   }
 
@@ -165,6 +173,12 @@ export class InputTextarea extends Component {
       } catch (e) {
         console.log(`${value} failed`)
         this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }'});
+      }
+    } else if (format === 'xpub') {
+      if (value.startsWith('xpub') && value.length === XPUB_LENGTH) {
+        this.setState({ error: null });
+      } else {
+        this.setState({ error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
       }
     }
   }

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -108,6 +108,12 @@ export class InputField extends Component {
       } else {
         this.setState({ error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
       }
+    } else if (format === 'number') {
+      if (value >= 0) {
+        this.setState({ error: null });
+      } else {
+        this.setState({ error: 'This field cannot be negative.' });
+      }
     }
   }
 

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -88,6 +88,11 @@ export class InputField extends Component {
 
   validate = () => {
     const { value, format } = this.props;
+
+    if (value === '') {
+      return;
+    }
+
     if (format === 'json') {
       try {
         JSON.parse(value);
@@ -148,6 +153,10 @@ export class InputTextarea extends Component {
 
   validate = () => {
     const { value, format } = this.props;
+
+    if (value === '') {
+      return;
+    }
 
     if (format === 'json') {
       try {

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -25,8 +25,8 @@ class NonBitGoRecoveryForm extends Component {
     env: 'test'
   };
 
-  updateRecoveryInfo = (fieldName) => (event) => {
-    this.setState({ [fieldName]: event.target.value });
+  updateRecoveryInfo = (field) => (value) => {
+    this.setState({ [field]: value });
   }
 
   updateEnv = (option) => {
@@ -155,75 +155,86 @@ class NonBitGoRecoveryForm extends Component {
           <InputTextarea
             label='Box A Value'
             name='userKey'
-            onChange={this.updateRecoveryInfo('userKey')}
             value={this.state.userKey}
+            onChange={this.updateRecoveryInfo}
             tooltipText={formTooltips.userKey}
+            disallowWhiteSpace={true}
+            format='json'
           />
           <InputTextarea
             label='Box B Value'
             name='backupKey'
-            onChange={this.updateRecoveryInfo('backupKey')}
             value={this.state.backupKey}
+            onChange={this.updateRecoveryInfo}
             tooltipText={formTooltips.backupKey}
+            disallowWhiteSpace={true}
+            format='json'
           />
           {!['xrp', 'eth', 'token'].includes(this.state.coin) &&
             <InputField
               label='Box C Value'
               name='bitgoKey'
-              onChange={this.updateRecoveryInfo('bitgoKey')}
               value={this.state.bitgoKey}
+              onChange={this.updateRecoveryInfo}
               tooltipText={formTooltips.bitgoKey}
+              disallowWhiteSpace={true}
             />
           }
           {this.state.coin === 'xrp' &&
             <InputField
               label='Root Address'
               name='rootAddress'
-              onChange={this.updateRecoveryInfo('rootAddress')}
               value={this.state.rootAddress}
+              onChange={this.updateRecoveryInfo}
               tooltipText={formTooltips.rootAddress}
+              disallowWhiteSpace={true}
             />
           }
           {['eth', 'token'].includes(this.state.coin) &&
             <InputField
               label='Wallet Contract Address'
               name='walletContractAddress'
-              onChange={this.updateRecoveryInfo('walletContractAddress')}
               value={this.state.walletContractAddress}
+              onChange={this.updateRecoveryInfo}
               tooltipText={formTooltips.walletContractAddress}
+              disallowWhiteSpace={true}
             />
           }
           {this.state.coin === 'token' &&
           <InputField
             label='Token Contract Address'
             name='tokenAddress'
-            onChange={this.updateRecoveryInfo('tokenAddress')}
             value={this.state.tokenAddress}
+            onChange={this.updateRecoveryInfo}
             tooltipText={formTooltips.tokenAddress}
+            disallowWhiteSpace={true}
           />
           }
           <InputField
             label='Wallet Passphrase'
             name='walletPassphrase'
-            onChange={this.updateRecoveryInfo('walletPassphrase')}
             value={this.state.walletPassphrase}
-            isPassword={true}
+            onChange={this.updateRecoveryInfo}
             tooltipText={formTooltips.walletPassphrase}
+            isPassword={true}
           />
           <InputField
             label='Destination Address'
             name='recoveryDestination'
-            onChange={this.updateRecoveryInfo('recoveryDestination')}
             value={this.state.recoveryDestination}
+            onChange={this.updateRecoveryInfo}
             tooltipText={formTooltips.recoveryDestination}
+            disallowWhiteSpace={true}
           />
           {!['xrp', 'eth', 'token'].includes(this.state.coin) &&
             <InputField
               label='Address Scanning Factor'
               name='scan'
-              onChange={this.updateRecoveryInfo('scan')}
               value={this.state.scan}
+              onChange={this.updateRecoveryInfo}
               tooltipText={formTooltips.scan}
+              disallowWhiteSpace={true}
+              format='number'
             />
           }
           {this.state.error && <ErrorMessage>{this.state.error}</ErrorMessage>}

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -178,6 +178,7 @@ class NonBitGoRecoveryForm extends Component {
               onChange={this.updateRecoveryInfo}
               tooltipText={formTooltips.bitgoKey}
               disallowWhiteSpace={true}
+              format='xpub'
             />
           }
           {this.state.coin === 'xrp' &&


### PR DESCRIPTION
Adds realtime input validation to non-BitGo and cross-chain recoveries. Supports:
 - Disabling whitespace on a field - whitespace is automatically removed on type or paste (useful for keycard values which preserve newlines)
 - Enforcing numerical input - currently only used for address scanning factor
 - Enforcing JSON object input - useful for keycard values, error text explains the format of a JSON object in simple terms

Also bumps reactstrap version to latest for some form eyecandy and modifies a couple of conventions