### PR TITLE
[BG-5602] Make WRW window resizable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ const template = [{
 
 function createWindow() {
     // Create the browser window.
-    mainWindow = new BrowserWindow({ width: 1366, height: 768, resizable: false });
+    mainWindow = new BrowserWindow({ width: 1366, height: 768, resizable: true, minWidth: 1366, minHeight: 768 });
 
     // and load the index.html of the app.
     const startUrl = process.env.ELECTRON_START_URL || url.format({


### PR DESCRIPTION
Window can now be resized to larger than the default size. This will be especially useful when the bulk wrong chain recovery PR is landed, as users may want to see all transaction IDs on one screen.