### PR TITLE
[BG-10087] XLM box B should expect XLM pub, not xpub

### DIFF
--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -110,10 +110,21 @@ export class InputField extends Component {
         this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }' });
       }
     } else if (format === 'xpub') {
-      if (value.startsWith('xpub') && value.length === XPUB_LENGTH) {
-        this.setState({ error: null });
+      if (!coin) {
+        return;
+      }
+      if (coin.getFamily() !== 'xlm') {
+        if (value.startsWith('xpub') && value.length === XPUB_LENGTH) {
+          this.setState({error: null});
+        } else {
+          this.setState({error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
+        }
       } else {
-        this.setState({ error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
+        if (coin.isValidAddress(value)) {
+          this.setState({error: null});
+        } else {
+          this.setState({error: `This field should be a ${coin.getFamily().toUpperCase()} address. Addresses begin with the letter G`});
+        }
       }
     } else if (format === 'number') {
       if (value >= 0) {

--- a/src/components/form-components.js
+++ b/src/components/form-components.js
@@ -109,21 +109,17 @@ export class InputField extends Component {
       } catch (e) {
         this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }' });
       }
-    } else if (format === 'xpub') {
+    } else if (format === 'pub') {
       if (!coin) {
         return;
       }
-      if (coin.getFamily() !== 'xlm') {
-        if (value.startsWith('xpub') && value.length === XPUB_LENGTH) {
-          this.setState({error: null});
-        } else {
-          this.setState({error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
-        }
+      if (coin.isValidPub(value)) {
+        this.setState({error: null});
       } else {
-        if (coin.isValidAddress(value)) {
-          this.setState({error: null});
+        if (coin.getFamily() === 'xlm') {
+          this.setState({ error: `This field should be a Stellar public key. Stellar public keys begin with a G.` });
         } else {
-          this.setState({error: `This field should be a ${coin.getFamily().toUpperCase()} address. Addresses begin with the letter G`});
+          this.setState({ error: `This field should be a public key. Public keys begin with the word 'xpub' and have a total length of ${XPUB_LENGTH} characters.`});
         }
       }
     } else if (format === 'number') {
@@ -208,7 +204,7 @@ export class InputTextarea extends Component {
         console.log(`${value} failed`)
         this.setState({ error: 'This field should be a JSON object. JSON objects begin with a { and end with a }'});
       }
-    } else if (format === 'xpub') {
+    } else if (format === 'pub') {
       if (value.startsWith('xpub') && value.length === XPUB_LENGTH) {
         this.setState({ error: null });
       } else {

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -225,6 +225,7 @@ class NonBitGoRecoveryForm extends Component {
                 tooltipText={formTooltips.backupPublicKey}
                 disallowWhiteSpace={true}
                 format='xpub'
+                coin={this.getCoinObject()}
               />
           )]
           }

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -224,7 +224,7 @@ class NonBitGoRecoveryForm extends Component {
                 onChange={this.updateRecoveryInfo}
                 tooltipText={formTooltips.backupPublicKey}
                 disallowWhiteSpace={true}
-                format='xpub'
+                format='pub'
                 coin={this.getCoinObject()}
               />
           )]
@@ -238,7 +238,7 @@ class NonBitGoRecoveryForm extends Component {
             onChange={this.updateRecoveryInfo}
             tooltipText={formTooltips.bitgoKey}
             disallowWhiteSpace={true}
-            format='xpub'
+            format='pub'
           />
           }
 


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-10087

Currently we get an error when inputting an XLM key as the backup key, on an XLM recovery, even though that should be expected. The message says it expects an xpub, which is not true. It should expect an XLM pub key for XLM

<img width="868" alt="screen shot 2019-01-22 at 15 07 03" src="https://user-images.githubusercontent.com/43550949/51570810-f8193b00-1e54-11e9-8f84-0c6bf8e75a2b.png">
