### PR TITLE
BG-10871 change dai to das

### DIFF
--- a/src/constants/krs-providers.js
+++ b/src/constants/krs-providers.js
@@ -8,7 +8,7 @@ export default [
     value: 'bitgoKRSv2'
   },
   {
-    label: 'DAI',
+    label: 'DAS',
     value: 'dai'
   }
 ];


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-10871

Digital Asset "Services" is their new name

Also - not a bad idea to keep them as "dai" on the backend - we won't get confused with the other "DAS" that liquidity is working on