### PR TITLE
BG-11479 fix unsupported erc-20 token recoveries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BitGoWalletRecoveryWizard",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "main": "src/main.js",
   "homepage": "./",

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -15,7 +15,8 @@ export default {
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',
     recoveryAddress: 'The address your recovered tokens will be sent to. This address should belong to a non-BitGo wallet that supports the token.',
     passphrase: 'The wallet passphrase of the wallet that received the unsupported token. You can leave this blank if you know the private key.',
-    prv: 'The private key (xprv) of the wallet that received the unsupported token. You can leave this blank if you know the wallet passphrase.'
+    prv: 'The private key (xprv) of the wallet that received the unsupported token. You can leave this blank if you know the wallet passphrase.',
+    twofa: 'Second factor authentication (2FA) code'
   },
   recovery: {
     userKey: `Your encrypted user key, as found on your recovery KeyCard.`,


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-11479

The WRW should be able to broadcast unsupported token recoveries without going through BitGo support. 

The reason is that currently, attempting to recover unsupported tokens from a live ETH wallet will mess up the the sequence ID's of the smart contract. By broadcasting from the WRW, we eliminate this issue. 

Tested locally by Danny