### PR TITLE
BG-11084 update build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "out-clean": "rm -rf ./out/*",
     "electron": "electron .",
     "build": "NODE_ENV=production node scripts/build.js",
-    "make": "export NODE_ENV=production && node scripts/build.js && electron-forge make -p 'darwin' && electron-forge make -p 'win32'"
+    "make": "export NODE_ENV=production && node scripts/build.js && electron-forge make -p 'darwin'",
+    "make-windows": ".\\node_modules\\.bin\\electron-rebuild.cmd && set NODE_ENV=production&& node scripts/build.js && electron-forge make -p win32",
+    "make-linux": "export NODE_ENV=production && node scripts/build.js && electron-forge make -p 'linux'"
   },
   "dependencies": {
     "@babel/polyfill": "7.2.5",
@@ -126,6 +128,9 @@
         ],
         "darwin": [
           "dmg"
+        ],
+        "linux": [
+          "deb"
         ]
       },
       "electronPackagerConfig": {


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-11084

Now that we have the ledger tool's prebuilt binaries, we have to build the Mac dmg on a Mac machine, the Windows exe on a Windows machine, and the Linux .deb on a Linux machine.

This PR updates the build script to include the linux option, and it also separates the Mac/Windows build into two separate commands.