### PR TITLE
BG-12973 update zcash block explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "main": "src/main.js",
   "homepage": "./",


### PR DESCRIPTION
Zcash block explorer is dead and we need to update it
https://bitgoinc.atlassian.net/browse/BG-12973
https://bitgo.freshdesk.com/a/tickets/91461