### PR TITLE
Make release compatible with 32bit windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "out-clean": "rm -rf ./out/*",
     "electron": "electron .",
     "build": "NODE_ENV=production node scripts/build.js",
-    "make": "export NODE_ENV=production && node scripts/build.js && electron-forge make -p 'darwin' && electron-forge make -p 'win32' && electron-forge make -p 'linux'"
+    "make": "export NODE_ENV=production && node scripts/build.js && electron-forge make -p 'darwin' && electron-forge make -p 'win32' --arch ia32 && electron-forge make -p 'linux'"
   },
   "dependencies": {
     "autoprefixer": "8.6.5",


### PR DESCRIPTION
Currently the WRW release process creates a 64-bit windows
application. This PR changes that to 32-bit to make it
compatible with both 32 and 64-bit architecture

Ticket: BG-17573