### PR TITLE
Fix env usage issues in BitGoJS

### DIFF
--- a/src/components/cross-chain.js
+++ b/src/components/cross-chain.js
@@ -119,8 +119,8 @@ class CrossChainRecoveryForm extends Component {
       prv
     } = this.state;
 
-    const sourceCoin = bitgo.env === 'prod' ? this.state.sourceCoin : 't' + this.state.sourceCoin;
-    const recoveryCoin = bitgo.env === 'prod' ? this.state.recoveryCoin : 't' + this.state.recoveryCoin;
+    const sourceCoin = bitgo.getEnv() === 'prod' ? this.state.sourceCoin : 't' + this.state.sourceCoin;
+    const recoveryCoin = bitgo.getEnv() === 'prod' ? this.state.recoveryCoin : 't' + this.state.recoveryCoin;
 
     this.setState({ error: '' });
 
@@ -331,7 +331,7 @@ class RecoveryTxForm extends Component {
             tooltipText={formTooltips.recoveryAddress(formState.sourceCoin)}
             disallowWhiteSpace={true}
             format='address'
-            coin={bitgo.coin(bitgo.env === 'prod' ? formState.sourceCoin : 't' + formState.sourceCoin)}
+            coin={bitgo.coin(bitgo.getEnv() === 'prod' ? formState.sourceCoin : 't' + formState.sourceCoin)}
           />
           {formState.signed &&
           <InputField

--- a/src/components/migrated-legacy.js
+++ b/src/components/migrated-legacy.js
@@ -187,7 +187,7 @@ class MigratedRecoveryForm extends Component {
     const { bitgo } = this.props;
     this.setState({ error: '', recovering: true });
 
-    const coinName = this.props.bitgo.env === 'prod' ? this.state.coin : `t${this.state.coin}`
+    const coinName = this.props.bitgo.getEnv() === 'prod' ? this.state.coin : `t${this.state.coin}`
     const coin = bitgo.coin(coinName);
     const wallets = await coin.wallets().list();
 
@@ -205,7 +205,7 @@ class MigratedRecoveryForm extends Component {
     // If we are recovering BSV, then the code above finds a BCH wallet (migratedWallet)
     // If that is the case, then we need to dig deeper and get the original v1 BTC wallet, and reset migratedWallet to this v1 BTC wallet
     if (coin.getFamily() === 'bsv') {
-      const bch = bitgo.coin(this.props.bitgo.env === 'prod' ? 'bch' : `tbch`);
+      const bch = bitgo.coin(this.props.bitgo.getEnv() === 'prod' ? 'bch' : `tbch`);
       const bchWallet = await bch.wallets().getWallet({ id: this.state.walletId });
       if (!bchWallet) {
         throw new Error(`could not find the original v1 btc wallet corresponding to the bch wallet with ID ${this.state.walletId}`);
@@ -269,8 +269,8 @@ class MigratedRecoveryForm extends Component {
 
   render() {
     const mainnetCoin = this.state.coin;
-    const coin = this.props.bitgo.env === 'prod' ? mainnetCoin : `t${mainnetCoin}`;
-    const migratedCoins = coinConfig.supportedRecoveries.migrated[this.props.bitgo.env];
+    const coin = this.props.bitgo.getEnv() === 'prod' ? mainnetCoin : `t${mainnetCoin}`;
+    const migratedCoins = coinConfig.supportedRecoveries.migrated[this.props.bitgo.getEnv()];
     return (
       <div>
         <h1 className='content-header'>Migrated Legacy Wallet Recoveries</h1>

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -86,7 +86,7 @@ class NonBitGoRecoveryForm extends Component {
 
     let baseCoin = await this.getCoinObject();
 
-    this.props.bitgo.env = this.state.env;
+    this.props.bitgo._env = this.state.env;
 
     const recoveryTool = baseCoin.recover;
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -137,7 +137,7 @@ class UnsignedSweep extends Component {
 
     let baseCoin = await this.getCoinObject();
 
-    this.props.bitgo.env = this.state.env;
+    this.props.bitgo._env = this.state.env;
 
     const recoveryTool = baseCoin.recover;
 

--- a/src/components/unsupported-token.js
+++ b/src/components/unsupported-token.js
@@ -74,7 +74,7 @@ class UnsupportedTokenRecoveryForm extends Component {
 
     this.setState({ error: '', recovering: true });
 
-    const coin = bitgo.env === 'prod' ? 'eth' : 'teth';
+    const coin = bitgo.getEnv() === 'prod' ? 'eth' : 'teth';
     await bitgo.unlock({ otp: twofa });
     try {
       const wallet = await bitgo.coin(coin).wallets().get({ id: walletId });
@@ -105,7 +105,7 @@ class UnsupportedTokenRecoveryForm extends Component {
   saveTransaction = () => {
     const fileData = this.state.recoveryTx;
     let fileName;
-    const filePrefix = this.props.bitgo.env === 'prod' ? 'erc20' : 'terc20';
+    const filePrefix = this.props.bitgo.getEnv() === 'prod' ? 'erc20' : 'terc20';
 
     fileName = `${filePrefix}r-${fileData.halfSigned.operationHash.slice(2,8)}-${moment().format('YYYYMMDD')}.signed.json`;
 
@@ -133,7 +133,7 @@ class UnsupportedTokenRecoveryForm extends Component {
   }
 
   render() {
-    const coin = this.props.bitgo.env === 'prod' ? 'eth' : 'teth';
+    const coin = this.props.bitgo.getEnv() === 'prod' ? 'eth' : 'teth';
 
     return (
       <div>


### PR DESCRIPTION
BitGoJS now uses _env instead of env, and also has
a new function getEnv() that should be used when possible.
This updates the WRW to properly use these

Ticket: BG-18417