### PR TITLE
Upgrade bitgojs, improve docs, fix Coincover

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,27 @@ npm install
 ./node_modules/.bin/electron-rebuild
 npm run start # run a development server and start the app
 ```
+## Releasing
+First, bump the version in package.json, then:
+```shell
+npm run make
+```
+Three files will be created:
+```shell
+./out/make/bitgowalletrecoverywizard_VERSION_amd64.deb
+./out/make/BitGoWalletRecoveryWizard-VERSION.dmg
+./out/make/squirrel.windows/ia32/BitGoWalletRecoveryWizard-VERSION Setup.exe
+```
+For each of these, do:
+```shell
+shasum -a 256 <filename>
+```
+And copy the hash.
+
+then:
+
+- Go back to the Releases list and click "Draft a new release"
+- Set the title and tag to "vx.y.z"
+- Paste the template into the description and update the SHA-256 hashes at the bottom
+- Upload the binaries in the file picker at the bottom
+- Publish the release!

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "main": "src/main.js",
   "homepage": "./",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "autoprefixer": "8.6.5",
-    "bitgo": "^9.5.1",
+    "bitgo": "^9.6.0-rc",
     "bitgo-utxo-lib": "^1.8.0",
     "bootstrap": "^4.3.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",

--- a/src/constants/krs-providers.js
+++ b/src/constants/krs-providers.js
@@ -8,7 +8,7 @@ export default [
     value: 'bitgoKRSv2'
   },
   {
-    label: 'DAS',
-    value: 'dai'
+    label: 'Coincover',
+    value: 'dai' // Coincover used to be called 'DAI' and so on the backend, BitGo still refers to them as 'dai'
   }
 ];


### PR DESCRIPTION
As part of my departure, I want to get WRW into
a good state. Let's get it to the latest bitgojs
which will fix a BTG recovery error. This PR
also adds Release info to the Readme and fixes the
name of Coincover

Ticket: BG-18467