### PR TITLE
BG-24608 Accept API Key in non-BitGo Recovery and Unsigned Sweep

### DIFF
--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -32,7 +32,7 @@ class NonBitGoRecoveryForm extends Component {
   };
 
   requiredParams = {
-    btc: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
+    btc: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan', 'apiKey'],
     bch: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
     ltc: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
     btg: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
@@ -117,6 +117,10 @@ class NonBitGoRecoveryForm extends Component {
         return obj;
       }, {});
 
+      if(this.state.coin === 'btc'&& this.state.apiKey) {
+        recoveryParams.apiKey = this.state.apiKey
+      }
+
       if (!coinConfig.allCoins[this.state.coin].recoverP2wsh) {
         recoveryParams.ignoreAddressTypes = ['p2wsh'];
       }
@@ -139,16 +143,17 @@ class NonBitGoRecoveryForm extends Component {
       };
 
       // Retrieve the desired file path and file name
-      const filePath = dialog.showSaveDialog(dialogParams);
+      const filePath = await dialog.showSaveDialog(dialogParams);
       if (!filePath) {
         // TODO: The user exited the file creation process. What do we do?
         return;
       }
 
-      fs.writeFileSync(filePath, JSON.stringify(recovery, null, 4), 'utf8');
+      fs.writeFileSync(filePath.filePath, JSON.stringify(recovery, null, 4), 'utf8');
 
-      this.setState({ recovering: false, done: true, finalFilename: filePath });
+      this.setState({ recovering: false, done: true, finalFilename: [filePath.filePath] });
     } catch (e) {
+      console.dir(e)
       this.setState({ error: e.message, recovering: false });
     }
   }
@@ -354,7 +359,7 @@ class NonBitGoRecoveryForm extends Component {
             label='API Key'
             name='apiKey'
             onChange={this.updateRecoveryInfo}
-            tooltipText={formTooltips.apiKey}
+            tooltipText={formTooltips.apiKey(this.state.coin)}
             disallowWhiteSpace={true}
             placeholder='None'
           />

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -9,7 +9,7 @@ import * as BitGoJS from 'bitgo/dist/browser/BitGoJS.min';
 import tooltips from 'constants/tooltips';
 import coinConfig from 'constants/coin-config';
 import krsProviders from 'constants/krs-providers';
-
+import { logToConsole } from 'utils.js';
 const formTooltips = tooltips.recovery;
 const { dialog } = window.require('electron').remote;
 const fs = window.require('fs');
@@ -117,8 +117,8 @@ class NonBitGoRecoveryForm extends Component {
         return obj;
       }, {});
 
-      if(this.state.coin === 'btc'&& this.state.apiKey) {
-        recoveryParams.apiKey = this.state.apiKey
+      if (this.state.coin === 'btc' && this.state.apiKey) {
+        recoveryParams.apiKey = this.state.apiKey;
       }
 
       if (!coinConfig.allCoins[this.state.coin].recoverP2wsh) {
@@ -152,9 +152,10 @@ class NonBitGoRecoveryForm extends Component {
       fs.writeFileSync(filePath.filePath, JSON.stringify(recovery, null, 4), 'utf8');
 
       this.setState({ recovering: false, done: true, finalFilename: [filePath.filePath] });
-      alert('We recommend that you use a third-party API to decode your txHex and verify its accuracy before broadcasting.');
+      alert('We recommend that you use a third-party API to decode your txHex' + 
+            'and verify its accuracy before broadcasting.');
     } catch (e) {
-      console.dir(e)
+      logToConsole(e);
       this.setState({ error: e.message, recovering: false });
     }
   }

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -152,6 +152,7 @@ class NonBitGoRecoveryForm extends Component {
       fs.writeFileSync(filePath.filePath, JSON.stringify(recovery, null, 4), 'utf8');
 
       this.setState({ recovering: false, done: true, finalFilename: [filePath.filePath] });
+      alert('We recommend that you use a third-party API to decode your txHex and verify its accuracy before broadcasting.');
     } catch (e) {
       console.dir(e)
       this.setState({ error: e.message, recovering: false });

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -162,7 +162,7 @@ class UnsignedSweep extends Component {
         return obj;
       }, {});
 
-      if (this.state.coin === 'btc'&& this.state.apiKey) {
+      if (this.state.coin === 'btc' && this.state.apiKey) {
         recoveryParams.apiKey = this.state.apiKey;
       }
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -188,6 +188,7 @@ class UnsignedSweep extends Component {
 
       fs.writeFileSync(filePath.filePath, JSON.stringify(recoveryPrebuild, null, 4), 'utf8');
       this.setState({ recovering: false, done: true, finalFilename: filePath.filePath });
+      alert('We recommend that you use a third-party API to decode your txHex and verify its accuracy before broadcasting.');
     } catch (e) {
       console.dir(e);
       this.setState({ error: e.message, recovering: false });

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -33,7 +33,7 @@ class UnsignedSweep extends Component {
   };
 
   displayedParams = {
-    btc: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
+    btc: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan', 'apiKey'],
     bch: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
     ltc: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
     btg: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
@@ -162,6 +162,10 @@ class UnsignedSweep extends Component {
         return obj;
       }, {});
 
+      if(this.state.coin === 'btc'&& this.state.apiKey) {
+        recoveryParams.apiKey = this.state.apiKey
+      }
+
       this.updateKeysFromIDs(baseCoin, recoveryParams);
 
       const recoveryPrebuild = await baseCoin.recover(recoveryParams);
@@ -176,15 +180,16 @@ class UnsignedSweep extends Component {
       };
 
       // Retrieve the desired file path and file name
-      const filePath = dialog.showSaveDialog(dialogParams);
+      const filePath = await dialog.showSaveDialog(dialogParams);
       if (!filePath) {
         // TODO: The user exited the file creation process. What do we do?
         return;
       }
 
-      fs.writeFileSync(filePath, JSON.stringify(recoveryPrebuild, null, 4), 'utf8');
-      this.setState({ recovering: false, done: true, finalFilename: filePath });
+      fs.writeFileSync(filePath.filePath, JSON.stringify(recoveryPrebuild, null, 4), 'utf8');
+      this.setState({ recovering: false, done: true, finalFilename: filePath.filePath });
     } catch (e) {
+      console.dir(e);
       this.setState({ error: e.message, recovering: false });
     }
   }
@@ -372,6 +377,17 @@ class UnsignedSweep extends Component {
             tooltipText={formTooltips.scan}
             disallowWhiteSpace={true}
             format='number'
+          />
+          }
+
+          {this.displayedParams[this.state.coin].includes('apiKey') &&
+          <InputField
+            label='API Key'
+            name='apiKey'
+            onChange={this.updateRecoveryInfo}
+            tooltipText={formTooltips.apiKey(this.state.coin)}
+            disallowWhiteSpace={true}
+            placeholder='None'
           />
           }
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -8,7 +8,7 @@ import ErrorMessage from './error-message';
 import tooltips from 'constants/tooltips';
 import coinConfig from 'constants/coin-config';
 import krsProviders from 'constants/krs-providers';
-
+import { logToConsole } from 'utils.js';
 const fs = window.require('fs');
 const formTooltips = tooltips.unsignedSweep;
 const { dialog } = window.require('electron').remote;
@@ -99,7 +99,7 @@ class UnsignedSweep extends Component {
       const derivedNode = node.derivePath(path);
       return derivedNode.toBase58();
     } catch(err) {
-      console.dir(err);
+      logToConsole(err);
       throw err;
     }
   }
@@ -162,8 +162,8 @@ class UnsignedSweep extends Component {
         return obj;
       }, {});
 
-      if(this.state.coin === 'btc'&& this.state.apiKey) {
-        recoveryParams.apiKey = this.state.apiKey
+      if (this.state.coin === 'btc'&& this.state.apiKey) {
+        recoveryParams.apiKey = this.state.apiKey;
       }
 
       this.updateKeysFromIDs(baseCoin, recoveryParams);
@@ -188,9 +188,10 @@ class UnsignedSweep extends Component {
 
       fs.writeFileSync(filePath.filePath, JSON.stringify(recoveryPrebuild, null, 4), 'utf8');
       this.setState({ recovering: false, done: true, finalFilename: filePath.filePath });
-      alert('We recommend that you use a third-party API to decode your txHex and verify its accuracy before broadcasting.');
+      alert('We recommend that you use a third-party API to decode your txHex' + 
+            'and verify its accuracy before broadcasting.');
     } catch (e) {
-      console.dir(e);
+      logToConsole(e);
       this.setState({ error: e.message, recovering: false });
     }
   }

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -31,9 +31,10 @@ export default {
     apiKey: (coin) => {
       if (coin === 'eth' || coin === 'token') {
         return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries';
-      }
-      if (coin === 'btc') {
+      } else if (coin === 'btc') {
         return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries';
+      } else {
+        return 'An Api-Key Token required to fetch information from the external service and perform recoveries';
       }
     },
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -28,7 +28,14 @@ export default {
     walletPassphrase: `The passphrase of the wallet.`,
     recoveryDestination: `The address your recovery transaction will send to.`,
     scan: 'The amount of addresses without transactions to scan before stopping the tool.',
-    apiKey: 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries',
+    apiKey: (coin) => {
+      if (coin === 'eth' || coin === 'token') {
+        return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries'
+      }
+      if( coin=== 'btc') {
+        return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries'
+      }
+    },
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',
     krsProvider: 'The Key Recovery Service that you chose to manage your backup key. If you have the encrypted backup key, you may leave this blank.'
   },

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -57,5 +57,10 @@ export default {
     recoveryDestination: `The address your recovery transaction will send to.`,
     scan: 'The amount of addresses without transactions to scan before stopping the tool.',
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',
+    apiKey: (coin) => {
+      if( coin === 'btc') {
+        return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries'
+      }
+    },
   },
 }

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -30,10 +30,10 @@ export default {
     scan: 'The amount of addresses without transactions to scan before stopping the tool.',
     apiKey: (coin) => {
       if (coin === 'eth' || coin === 'token') {
-        return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries'
+        return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries';
       }
-      if( coin=== 'btc') {
-        return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries'
+      if (coin === 'btc') {
+        return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries';
       }
     },
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',
@@ -58,8 +58,8 @@ export default {
     scan: 'The amount of addresses without transactions to scan before stopping the tool.',
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',
     apiKey: (coin) => {
-      if( coin === 'btc') {
-        return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries'
+      if (coin === 'btc') {
+        return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries';
       }
     },
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+/**
+ * A logger we use to log debugging information to the console
+ * @param {String} e 
+ */
+export function logToConsole(e) {
+  console.dir(e);
+}


### PR DESCRIPTION
For non-BitGo recoveries (non-BitGo and unsigned sweep), we add a new field on the UI to accept a blockchair API key for bitcoin Mainnet and testnet recoveries.

I just tested that this worked for a btc prod wallet.

This change depends on the sdk change here: [https://github.com/BitGo/BitGoJS/pull/868](url)