### PR TITLE
Add etherscan token field to unsigned sweep

### DIFF
--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -59,8 +59,12 @@ export default {
     scan: 'The amount of addresses without transactions to scan before stopping the tool.',
     tokenAddress: 'The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address.',
     apiKey: (coin) => {
-      if (coin === 'btc') {
+      if (coin === 'eth' || coin === 'token') {
+        return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries';
+      } else if (coin === 'btc') {
         return 'An Api-Key Token from blockchair.com required for Bitcoin Mainnet and Testnet recoveries';
+      } else {
+        return 'An Api-Key Token required to fetch information from the external service and perform recoveries';
       }
     },
   },


### PR DESCRIPTION
Ticket: BG-24094

Same as [BG-21679,](https://github.com/BitGo/wallet-recovery-wizard/pull/78/files) we need to accept an etherscan token for unsigned-sweep too.-