### PR TITLE
Bump patch version for bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "main": "resources/electron.js",
   "homepage": "./",


### PR DESCRIPTION
We fixed the [bug](https://github.com/BitGo/wallet-recovery-wizard/pull/91/files) that happened when trying to save transaction file for cross-chain recovery. Now bumping the version for a release. 

Ticket: BG-24516