### PR TITLE
Add apiKey param and remove Testnet for BCH

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "autoprefixer": "8.6.5",
     "bignumber.js": "^9.0.0",
-    "bitgo": "^11.5.1-rc.2",
+    "bitgo": "^11.7.1-rc.1",
     "bitgo-utxo-lib": "^1.8.0",
     "bootstrap": "^4.3.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -34,7 +34,7 @@ class NonBitGoRecoveryForm extends Component {
   requiredParams = {
     btc: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
     bsv: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan', 'apiKey'],
-    bch: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
+    bch: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan', 'apiKey'],
     ltc: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
     btg: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
     zec: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
@@ -118,7 +118,7 @@ class NonBitGoRecoveryForm extends Component {
         return obj;
       }, {});
 
-      if (this.state.coin === 'bsv' && this.state.apiKey) {
+      if ((this.state.coin === 'bsv' || this.state.coin === 'bch') && this.state.apiKey) {
         recoveryParams.apiKey = this.state.apiKey;
       }
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -37,7 +37,7 @@ class UnsignedSweep extends Component {
   displayedParams = {
     btc: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
     bsv: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan', 'apiKey'],
-    bch: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
+    bch: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan', 'apiKey'],
     ltc: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
     btg: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
     zec: ['userKey', 'userKeyID', 'backupKey', 'backupKeyID', 'bitgoKey', 'recoveryDestination', 'scan'],
@@ -168,7 +168,7 @@ class UnsignedSweep extends Component {
         return obj;
       }, {});
 
-      if (this.state.coin === 'bsv' && this.state.apiKey) {
+      if ((this.state.coin === 'bsv' || this.state.coin === 'bch') && this.state.apiKey) {
         recoveryParams.apiKey = this.state.apiKey;
       }
 

--- a/src/constants/coin-config.js
+++ b/src/constants/coin-config.js
@@ -124,11 +124,11 @@ export default {
   supportedRecoveries: {
     crossChain: ['btc', 'bch', 'ltc', 'bsv'],
     nonBitGo: {
-      test: ['btc', 'eth', 'xrp', 'bch', 'xlm', 'ltc', 'dash', 'zec', 'btg', 'token', 'trx'],
+      test: ['btc', 'eth', 'xrp', 'xlm', 'ltc', 'dash', 'zec', 'btg', 'token', 'trx'],
       prod: ['btc', 'bch', 'ltc', 'xrp', 'xlm', 'dash', 'zec', 'btg', 'eth', 'token', 'trx', 'bsv']
     },
     unsignedSweep: {
-      test:['btc', 'bch', 'ltc', 'xrp', 'xlm', 'dash', 'zec', 'btg', 'eth', 'token', 'trx'],
+      test:['btc', 'ltc', 'xrp', 'xlm', 'dash', 'zec', 'btg', 'eth', 'token', 'trx'],
       prod: ['btc', 'bch', 'ltc', 'xrp', 'xlm', 'dash', 'zec', 'btg', 'eth', 'token', 'trx', 'bsv']
     },
     migrated: {

--- a/src/constants/tooltips.js
+++ b/src/constants/tooltips.js
@@ -31,8 +31,8 @@ export default {
     apiKey: (coin) => {
       if (coin === 'eth' || coin === 'token') {
         return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries';
-      } else if (coin === 'bsv') {
-        return 'An Api-Key Token from blockchair.com required for Bitcoin SV Mainnet recoveries';
+      } else if (coin === 'bsv' || coin === 'bch') {
+        return 'An Api-Key Token from blockchair.com required for mainnet recovery of this coin';
       } else {
         return 'An Api-Key Token required to fetch information from the external service and perform recoveries';
       }
@@ -61,8 +61,8 @@ export default {
     apiKey: (coin) => {
       if (coin === 'eth' || coin === 'token') {
         return 'An Api-Key Token from etherscan.com required for Ethereum Mainnet recoveries';
-      } else if (coin === 'bsv') {
-        return 'An Api-Key Token from blockchair.com required for Bitcoin SV Mainnet recoveries';
+      } else if (coin === 'bsv' || coin === 'bch') {
+        return 'An Api-Key Token from blockchair.com required for mainnet recoveries of this coin';
       } else {
         return 'An Api-Key Token required to fetch information from the external service and perform recoveries';
       }


### PR DESCRIPTION
We now use blockchair as an explorer for BCH as well, so we need to add the API key field and remove support for testnet, since blockchair does not support BCH testnet.

Ticket: BG-24863