### PR TITLE
Add alternative userKey path to query addresses from

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BitGoWalletRecoveryWizard",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,9 +19,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+          "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
         }
       }
     },
@@ -52,9 +52,9 @@
           },
           "dependencies": {
             "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+              "version": "1.14.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+              "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
             }
           }
         },
@@ -102,9 +102,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+          "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
         }
       }
     },
@@ -182,9 +182,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+          "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
         }
       }
     },
@@ -13445,9 +13445,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+          "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
         }
       }
     },
@@ -16197,9 +16197,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+          "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
         }
       }
     },
@@ -18094,9 +18094,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.2.tgz",
+      "integrity": "sha512-wAH28hcEKwna96/UacuWaVspVLkg4x1aDM9JlzqaQTOFczCktkVAb5fmXChgandR1EraDPs2w8P+ozM+oafwxg=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -9,7 +9,7 @@ import * as BitGoJS from 'bitgo/dist/browser/BitGoJS.min';
 import tooltips from 'constants/tooltips';
 import coinConfig from 'constants/coin-config';
 import krsProviders from 'constants/krs-providers';
-import { logToConsole } from 'utils.js';
+import { logToConsole, recoverWithKeyPath } from 'utils.js';
 const formTooltips = tooltips.recovery;
 const { dialog } = window.require('electron').remote;
 const fs = window.require('fs');
@@ -126,7 +126,7 @@ class NonBitGoRecoveryForm extends Component {
         recoveryParams.ignoreAddressTypes = ['p2wsh'];
       }
 
-      const recovery = await baseCoin.recover(recoveryParams);
+      const recovery = await recoverWithKeyPath(baseCoin, recoveryParams);
 
       const recoveryTx = recovery.transactionHex || recovery.txHex || recovery.tx;
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -172,8 +172,31 @@ class UnsignedSweep extends Component {
       }
 
       this.updateKeysFromIDs(baseCoin, recoveryParams);
+      
+      const userKeyPaths = ['/0/0', '/0'];
+      const noInputErrMsg = 'No input to recover - aborting!';      
+      let recoveryPrebuild;
+      for (const path of userKeyPaths) {
+        recoveryParams['userKeyPath'] = path;
+        try {
+          recoveryPrebuild = await baseCoin.recover(recoveryParams);
+        } catch (e) {
+          // if this current path we try yields us no inputs to recover, we catch the 
+          // error and continue trying the next path
+          if (e.message !== noInputErrMsg) {
+            throw new Error(e.message);
+          }
+          // if we already have a recovery result, then it means the current path we try
+          // is the valid user path, and we can exit the forloop
+          if (recoveryPrebuild) {
+            break;
+          }
+        }
+      }
 
-      const recoveryPrebuild = await baseCoin.recover(recoveryParams);
+      if (!recoveryPrebuild) {
+        throw new Error(noInputErrMsg);
+      }
 
       const fileName = baseCoin.getChain() + '-unsigned-sweep-' + Date.now().toString() + '.json';
       const dialogParams = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,16 +29,16 @@ export async function recoverWithKeyPath(baseCoin, recoveryParams) {
 
     try {
       recoveryPrebuild = await baseCoin.recover(recoveryParams);
+      // if we already have a recovery result, then it means the current path we try
+      // is the valid user path, and we can return and exit the iteration loop
+      if (recoveryPrebuild) {
+        return recoveryPrebuild;
+      }
     } catch (e) {
       // if this current path we try yields us no inputs to recover, we catch the
-      // error and continue trying the next path
+      // error and move on to the next iteration and continue trying the remaining paths
       if (e.constructor.name !== Errors.ErrorNoInputToRecover.name) {
         throw new Error(e.message);
-      }
-      // if we already have a recovery result, then it means the current path we try
-      // is the valid user path, and we can exit the forloop
-      if (recoveryPrebuild) {
-        break;
       }
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,47 @@
+import * as Errors from 'bitgo/dist/src/errors';
 /**
  * A logger we use to log debugging information to the console
- * @param {String} e 
+ * @param {String} e
  */
 export function logToConsole(e) {
   console.dir(e);
 }
+
+/**
+ * Call the recover() function with recoveryParams, and try multiple key paths for the user key
+ * @param {Object} baseCoin 
+ * @param {Object} recoveryParams 
+ * - backupKey: [encrypted] xprv, or xpub if the xprv is held by a KRS provider
+ * - walletPassphrase: necessary if one of the xprvs is encrypted
+ * - bitgoKey: xpub
+ * - krsProvider: necessary if backup key is held by KRS
+ * - recoveryDestination: target address to send recovered funds to
+ * - scan: the amount of consecutive addresses without unspents to scan through before stopping
+ * - ignoreAddressTypes: (optional) array of AddressTypes to ignore, these are strings defined in Codes.UnspentTypeTcomb
+ *        for example: ['p2shP2wsh', 'p2wsh'] will prevent code from checking for wrapped-segwit and native-segwit chains on the public block explorers 
+ */
+export async function recoverWithKeyPath(baseCoin, recoveryParams) {
+  const userKeyPaths = ['/0/0', '/0'];
+  let recoveryPrebuild;
+
+  for (const path of userKeyPaths) {
+    recoveryParams['userKeyPath'] = path;
+
+    try {
+      recoveryPrebuild = await baseCoin.recover(recoveryParams);
+    } catch (e) {
+      // if this current path we try yields us no inputs to recover, we catch the
+      // error and continue trying the next path
+      if (e.constructor.name !== Errors.ErrorNoInputToRecover.name) {
+        throw new Error(e.message);
+      }
+      // if we already have a recovery result, then it means the current path we try
+      // is the valid user path, and we can exit the forloop
+      if (recoveryPrebuild) {
+        break;
+      }
+    }
+  }
+  return recoveryPrebuild;
+}
+


### PR DESCRIPTION
 - Some of our v1 user key have key paths that are different from
   our default key path for v2 keys, and they have addresses that are
   currently un-derivable, with our current assumption of user 
   key path. We add a helper function that keeps an array of possible
   key paths to try from, with some alternatives, in case the default key 
   path was not used when the key was generated

- Pulled out the `recover` logic from `unsigned-sweep` and `non-bitgo`
   to the helper function above, reducing duplicate code

- this PR depends on https://github.com/BitGo/BitGoJS/pull/917, so
   please review that PR first. 

- This PR also updates the SDK and WRW versions

Ticket: BG-24941