### PR TITLE
Add separate button "Copy Debug Info"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,9 +7,25 @@ import Login from 'views/login';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'react-select/dist/react-select.css';
 import './App.css';
+import { BitGo } from 'bitgo';
+
+function getBitgoInstanceFromEnv() {
+  const env = process.env['REACT_APP_BITGO_ENV'];
+  const token = process.env['REACT_APP_BITGO_TOKEN'];
+  if (!token || !env) {
+    return undefined;
+  }
+  return new BitGo({ env, accessToken: token });
+}
 
 class App extends Component {
-  state = { isLoggedIn: false, loginBypass: false, bitgo: null };
+  constructor() {
+    super();
+    const bitgo = getBitgoInstanceFromEnv();
+    this.state = bitgo
+      ? { isLoggedIn: false, loginBypass: true, bitgo }
+      : { isLoggedIn: false, loginBypass: false, bitgo: null };
+  }
 
   updateLoginState = (isLoggedIn) => (bitgoInstance, utxoLibInstance) => {
     if (isLoggedIn && !bitgoInstance) {

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { BrowserRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
+import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
 
 import Dashboard from 'views/dashboard';
 import Login from 'views/login';

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -62,11 +62,12 @@ class NonBitGoRecoveryForm extends Component {
     ],
   };
 
-  copyErrorInfo() {
+  copyDebugInfo() {
+    const { error, recoveryDebugInfo } = this.state;
     const errorInfo = {
-      errorMessage: this.state.error.message,
-      errorStack: this.state.error.stack,
-      recoveryDebugInfo: this.state.recoveryDebugInfo,
+      errorMessage: error && error.message,
+      errorStack: error && error.stack,
+      recoveryDebugInfo,
     };
     clipboard.writeText(JSON.stringify(errorInfo, null, 2));
   }
@@ -424,17 +425,14 @@ class NonBitGoRecoveryForm extends Component {
               placeholder="None"
             />
           )}
-
           {this.state.error && <ErrorMessage>{this.state.error.message}</ErrorMessage>}
-
           {this.state.error && (
             <p>
-              <Button onClick={this.copyErrorInfo.bind(this)} className="bitgo-button">
+              <Button onClick={this.copyDebugInfo.bind(this)} className="bitgo-button">
                 Copy error info
               </Button>
             </p>
           )}
-
           {this.state.done && (
             <p className="recovery-logging">
               Completed constructing recovery transaction. Saved recovery file: {this.state.finalFilename}

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Select from 'react-select';
-import { InputField, InputTextarea, CoinDropdown, FieldTooltip } from './form-components';
-import { Alert, Form, Button, Row, Col, FormGroup, Label } from 'reactstrap';
+import { CoinDropdown, FieldTooltip, InputField, InputTextarea } from './form-components';
+import { Alert, Button, Col, Form, FormGroup, Label, Row } from 'reactstrap';
 import classNames from 'classnames';
 import ErrorMessage from './error-message';
 import * as BitGoJS from 'bitgo/dist/browser/BitGoJS.min';

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -10,26 +10,31 @@ import tooltips from 'constants/tooltips';
 import coinConfig from 'constants/coin-config';
 import krsProviders from 'constants/krs-providers';
 import { logToConsole, recoverWithKeyPath } from 'utils.js';
+
 const formTooltips = tooltips.recovery;
 const { dialog } = window.require('electron').remote;
 const fs = window.require('fs');
 
-class NonBitGoRecoveryForm extends Component {
-  state = {
-    coin: 'btc',
+function getEmptyState() {
+  return {
     userKey: '',
     backupKey: '',
     bitgoKey: '',
-    rootAddress: '',
+    coin: 'btc',
     walletContractAddress: '',
+    rootAddress: '',
     tokenAddress: '',
     walletPassphrase: '',
     recoveryDestination: '',
-    apiKey: '',
-    scan: 20,
-    krsProvider: null,
     env: 'test',
+    done: false,
+    error: '',
+    krsProvider: undefined,
   };
+}
+
+class NonBitGoRecoveryForm extends Component {
+  state = getEmptyState();
 
   requiredParams = {
     btc: ['userKey', 'backupKey', 'bitgoKey', 'walletPassphrase', 'recoveryDestination', 'scan'],
@@ -182,18 +187,7 @@ class NonBitGoRecoveryForm extends Component {
   }
 
   resetRecovery = () => {
-    this.setState({
-      userKey: '',
-      backupKey: '',
-      walletContractAddress: '',
-      rootAddress: '',
-      tokenAddress: '',
-      walletPassphrase: '',
-      recoveryDestination: '',
-      env: 'test',
-      done: false,
-      error: '',
-    });
+    this.setState(getEmptyState());
   };
 
   render() {

--- a/src/components/non-bitgo.js
+++ b/src/components/non-bitgo.js
@@ -32,6 +32,8 @@ function getEmptyState() {
     done: false,
     error: '',
     krsProvider: undefined,
+    apiKey: '',
+    scan: 20,
   };
 }
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -9,7 +9,7 @@ import * as Errors from 'bitgo/dist/src/errors';
 
 import tooltips from 'constants/tooltips';
 import coinConfig from 'constants/coin-config';
-import { logToConsole, recoverWithKeyPath } from 'utils.js';
+import { recoverWithKeyPath } from '../utils';
 const fs = window.require('fs');
 const formTooltips = tooltips.unsignedSweep;
 const { dialog } = window.require('electron').remote;
@@ -109,7 +109,7 @@ class UnsignedSweep extends Component {
       const derivedNode = node.derivePath(path);
       return derivedNode.toBase58();
     } catch (err) {
-      logToConsole(err);
+      console.error(err);
       throw err;
     }
   };
@@ -217,7 +217,7 @@ class UnsignedSweep extends Component {
           'and verify its accuracy before broadcasting.'
       );
     } catch (e) {
-      logToConsole(e);
+      console.error(e);
       this.setState({ error: e.message, recovering: false });
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,4 @@
 import * as Errors from 'bitgo/dist/src/errors';
-/**
- * A logger we use to log debugging information to the console
- * @param {String} e
- */
-export function logToConsole(e) {
-  console.dir(e);
-}
 
 /**
  * Call the recover() function with recoveryParams, and try multiple key paths for the user key

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,10 @@ import * as utxolib from '@bitgo/utxo-lib';
 
 import { AbstractUtxoCoin } from 'bitgo/dist/src/v2/coins';
 
+export function isDev() {
+  return process.env.NODE_ENV === 'development';
+}
+
 function sanitizeKeys(keys) {
   return keys.map((k) => {
     if (!(k instanceof utxolib.HDNode)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,11 @@
 import * as Errors from 'bitgo/dist/src/errors';
 
+const userKeyPaths = ['/0/0', '/0'];
+
+function withCustomKeyPath(params, userKeyPath) {
+  return Object.assign({}, params, { userKeyPath });
+}
+
 /**
  * Call the recover() function with recoveryParams, and try multiple key paths for the user key
  * @param {Object} baseCoin
@@ -15,18 +21,12 @@ import * as Errors from 'bitgo/dist/src/errors';
  */
 export async function recoverWithKeyPath(baseCoin, recoveryParams) {
   const userKeyPaths = ['/0/0', '/0'];
-  let recoveryPrebuild;
 
   for (const path of userKeyPaths) {
-    recoveryParams['userKeyPath'] = path;
-
     try {
-      recoveryPrebuild = await baseCoin.recover(recoveryParams);
       // if we already have a recovery result, then it means the current path we try
       // is the valid user path, and we can return and exit the iteration loop
-      if (recoveryPrebuild) {
-        return recoveryPrebuild;
-      }
+      return await baseCoin.recover(withCustomKeyPath(recoveryParams, path));
     } catch (e) {
       // if this current path we try yields us no inputs to recover, we catch the
       // error and move on to the next iteration and continue trying the remaining paths
@@ -38,8 +38,5 @@ export async function recoverWithKeyPath(baseCoin, recoveryParams) {
   // if we couldn't build a tx here, it must have been the case that there were no inputs available
   // to recover. All the other errors would have been caught and thrown already by the line:
   // if (e.constructor.name !== Errors.ErrorNoInputToRecover.name) { throw new Error(e.message);}
-  if (!recoveryPrebuild) {
-    throw new Errors.ErrorNoInputToRecover();
-  }
-  return recoveryPrebuild;
+  throw new Errors.ErrorNoInputToRecover();
 }


### PR DESCRIPTION
bf9f64c (Otto Allmendinger, 12 days ago)
   Rename to copyDebugInfo()

   Make `error` optional.

   Issue: BG-26842

e94b7e3 (Otto Allmendinger, 12 days ago)
   App reformat

   For some reason IntelliJ insists on that order

   Issue: BG-26842

2ad51ca (Otto Allmendinger, 13 days ago)
   Add "copy error info" button

   Copies error info to clipboard.

   Reorganize code a bit to have `try {}` block smaller.

   Issue: BG-26842

c83a77f (Otto Allmendinger, 13 days ago)
   Add getEmptyState()

   Make it easier to modify initial state.

d4fbc8f (Otto Allmendinger, 13 days ago)
   Add getRecoveryDebugInfo()

45e25dc (Otto Allmendinger, 13 days ago)
   Simplify recoverWithKeyPath

eeaa137 (Otto Allmendinger, 13 days ago)
   logToConsole: use `console.error()`

b39b65c (Otto Allmendinger, 13 days ago)
   Add `getBitgoInstanceFromEnv()`

   Allows more convenient development

   Issue: BG-26842