### PR TITLE
Fix issues with "instanceOf"

### DIFF
--- a/src/constants/coin-config.js
+++ b/src/constants/coin-config.js
@@ -143,4 +143,5 @@ export default {
       prod: ['bch', 'btg', 'bsv'],
     },
   },
+  supportKeyDerivationForDebugging: ['btc', 'bch', 'ltc', 'dash', 'zec', 'btg', 'bsv', 'bcha'],
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,7 @@
 import * as Errors from 'bitgo/dist/src/errors';
 
 import * as utxolib from '@bitgo/utxo-lib';
-
-import { AbstractUtxoCoin } from 'bitgo/dist/src/v2/coins';
+import coinConfig from './constants/coin-config';
 
 export function isDev() {
   return process.env.NODE_ENV === 'development';
@@ -10,19 +9,17 @@ export function isDev() {
 
 function sanitizeKeys(keys) {
   return keys.map((k) => {
-    if (!(k instanceof utxolib.HDNode)) {
+    if (k.constructor.name !== utxolib.HDNode.name) {
       throw new Error(`unexpected key`);
     }
-
     return k.neutered().toBase58();
   });
 }
 
 export async function getRecoveryDebugInfo(baseCoin, recoveryParams) {
-  if (!(baseCoin instanceof AbstractUtxoCoin)) {
-    // TODO support more coins
-    throw new Error('unsupported coin');
-  }
+   if (!coinConfig.supportKeyDerivationForDebugging.includes(baseCoin.getFamily())) {
+     return new Error('unsupported coin');
+   }
 
   return {
     // TODO include derive pubkeys


### PR DESCRIPTION
As mentioned in the comment [here](https://github.com/BitGo/wallet-recovery-wizard/pull/107#issuecomment-744068568), the use of 'instanceOf' does not actually help us check the desired class, this blocked us from using the debugging button.

Tested locally, producing results like:
```
{
  "errorMessage": "",
  "errorStack": "",
  "recoveryDebugInfo": {
    "publicKeys": [
      "xpub661MyMwAqRbcF6sE6BCY67SNEuGZQz9SEb2McBTYizUm27KwW11k6HcwRvAPHUPLaFVceZgYntaCLe5NFnRKa6QTuZNxAWK3txkiEeXLLfD",
      "xpub661MyMwAqRbcFmjpPybTDabAqT52gVrYtUnhD7sawgmuSjGFKBuvYkQ8CUo6g3116RqS1vmzmhruLyy7K9VKm9dY4H75dGSGB5xUWTUYiYh",
      "xpub661MyMwAqRbcG4N1kvajvzz61aRzA2kddX6pTbrbYKqnvqg42NDKEMQuCGf3XuVUEUHkX11bs1fJ4Lec8e1YHTtL5pLvRHsBuFgMAaPRhtP"
    ]
  }
}
```

Ticket: BG-27474