### PR TITLE
fix(wrw): fix eos testnet tx recovery issue

### DIFF
--- a/EOS.md
+++ b/EOS.md
@@ -9,6 +9,7 @@ If you found that these URLs are no longer valid, you can likely find newly host
 
 
 1) Find a fullnode URL. Below are a few known 3-party API endpoints for your reference:
+   
     Testnet Endpoints: https://monitor.jungletestnet.io/#apiendpoints
     
     Mainnet Endpoints: https://eos-api-list.herokuapp.com
@@ -17,8 +18,14 @@ If you found that these URLs are no longer valid, you can likely find newly host
 
     EOS Nation Endpoints: https://validate.eosnation.io/eos/reports/endpoints.html
 
+2) Ensure that your account is powered up to broadcast transaction on the network. Refer this link to know more about EOS Power Up Model.
+   https://eos.io/eos-public-blockchain/powerup-model/
 
-2) Construct your API request to the full node:
+   Testnet Endpoint: https://monitor.jungletestnet.io/#powerup
+
+   Mainnet Endpoint: https://bloks.io/wallet/powerup
+
+3) Construct your API request to the full node:
       
     API Endpoint: /v1/chain/push_transaction
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ The application currently offers the following recoveries:
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
 Please see the [releases page](https://github.com/BitGo/wallet-recovery-wizard/releases).
+
+## Important Documentation
+
+Instructions to broadcast EOS transactions: [EOS.md](EOS.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BitGoWalletRecoveryWizard",
-  "version": "2.8.11",
+  "version": "2.8.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1268,30 +1268,32 @@
       }
     },
     "@bitgo/account-lib": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/account-lib/-/account-lib-2.15.0.tgz",
-      "integrity": "sha512-WMogFPh30p4ApUjgCOOGdd20ubn6cCOXOyNNyLtAKrpE7Lq2iMr4GhO4hAR1m09KhaShbb4+n3qbsaVeSbwQ8g==",
+      "version": "2.16.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@bitgo/account-lib/-/account-lib-2.16.0-rc.17.tgz",
+      "integrity": "sha512-qPkesdDuXQSytIOAwrAMia0in4s1FQHXybmq0RvBYawchZ/j0BMT94hk8Hj/ivx0wn7Jp/4knyEGN0mYbLXQeg==",
       "requires": {
         "@bitgo/blake2b": "^3.0.1",
         "@bitgo/bls": "^0.1.0",
-        "@bitgo/statics": "^6.12.0",
-        "@bitgo/utxo-lib": "^1.9.6",
+        "@bitgo/statics": "^6.13.0-rc.10",
+        "@bitgo/utxo-lib": "^2.0.0-rc.1",
         "@celo/contractkit": "^1.2.4",
         "@ethereumjs/common": "^2.3.0",
         "@ethereumjs/tx": "^3.2.0",
         "@hashgraph/sdk": "^2.0.17",
         "@stablelib/hex": "^1.0.0",
         "@stablelib/sha384": "^1.0.0",
-        "@stacks/transactions": "1.4.1",
+        "@stacks/transactions": "2.0.1",
         "@taquito/local-forging": "6.3.5-beta.0",
         "@taquito/signer": "6.3.5-beta.0",
         "@types/lodash": "^4.14.151",
         "bignumber.js": "^9.0.0",
+        "bip32": "^2.0.6",
+        "bitcoinjs-lib": "^5.2.0",
         "bs58check": "^2.1.2",
         "casper-client-sdk": "1.0.39",
         "elliptic": "^6.5.2",
         "ethereumjs-abi": "^0.6.5",
-        "ethereumjs-util": "5.2.0",
+        "ethereumjs-util": "6.2.1",
         "ethereumjs-utils-old": "npm:ethereumjs-util@5.2.0",
         "ethers": "^5.1.3",
         "libsodium-wrappers": "^0.7.6",
@@ -1304,6 +1306,55 @@
         "tweetnacl": "^1.0.3"
       },
       "dependencies": {
+        "@bitgo/utxo-lib": {
+          "version": "2.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-2.0.0-rc.1.tgz",
+          "integrity": "sha512-6WzFi7QaxhAJM2b5U80saWTR48sLzV6KJbl1hvTkvG+G0Atou846bqXCbAc+gm5OTUtypFz0FIxGbFM7L+xmIw==",
+          "requires": {
+            "@bitgo/blake2b": "^3.0.1",
+            "bitcoin-ops": "^1.3.0",
+            "bitcoinjs-lib": "git+https://github.com/BitGo/bitcoinjs-lib.git#19fd098772",
+            "bs58check": "^2.0.0",
+            "typeforce": "^1.11.3",
+            "varuint-bitcoin": "^1.0.4"
+          },
+          "dependencies": {
+            "bitcoinjs-lib": {
+              "version": "git+https://github.com/BitGo/bitcoinjs-lib.git#19fd098772fa52ed9f3474b65b3f8fc44d8b5391",
+              "from": "git+https://github.com/BitGo/bitcoinjs-lib.git#19fd098772",
+              "requires": {
+                "bech32": "^2.0.0",
+                "bip174": "^2.0.1",
+                "bip32": "^2.0.4",
+                "bip66": "^1.1.0",
+                "bitcoin-ops": "^1.4.0",
+                "bs58check": "^2.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.3",
+                "merkle-lib": "^2.0.10",
+                "pushdata-bitcoin": "^1.0.1",
+                "randombytes": "^2.0.1",
+                "tiny-secp256k1": "^1.1.6",
+                "typeforce": "^1.11.3",
+                "varuint-bitcoin": "^1.0.4",
+                "wif": "^2.0.1"
+              }
+            }
+          }
+        },
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        },
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -1328,45 +1379,17 @@
           }
         },
         "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "requires": {
+            "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          },
-          "dependencies": {
-            "secp256k1": {
-              "version": "3.8.0",
-              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-              "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-              "requires": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.5.2",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
-              }
-            }
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
           }
         }
       }
@@ -1414,9 +1437,9 @@
       }
     },
     "@bitgo/statics": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-6.12.0.tgz",
-      "integrity": "sha512-XtPSMVF0GFWPw9vymx6ZjJJ6i95RJ1hwsLBHT7jeCa7kGDfg5oVMTEx57rNWfpQ6HqOCMoB0YGfozY0Z3BOsrA=="
+      "version": "6.13.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-6.13.0-rc.10.tgz",
+      "integrity": "sha512-Zbtg13mg1c3/IUzMrT9aQspcYVXTcVndcLcfykPdvuqAs0oPK6k3zE97jBPcGZPLAY1njEFN6WXF4Znb0fp5PQ=="
     },
     "@bitgo/unspents": {
       "version": "0.6.2",
@@ -1428,35 +1451,43 @@
       }
     },
     "@bitgo/utxo-lib": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-1.9.6.tgz",
-      "integrity": "sha512-b7bC5bzaiCrnVVt9epYWAhu1+ILPlgZK73YIHLHkYbcXxmCxk/nM8G6bXKdDCcRXAipnv2fLC3XTVVw1idfDdA==",
+      "version": "1.10.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-1.10.0-rc.13.tgz",
+      "integrity": "sha512-6fEJxQ1lAcp3dYhM61QyxDcCmHDF0CO3QcG7nv3aXavzUqCvLCJ4WPgDGSb5GqGIQJdDYU2pqfLrxG9q858W4A==",
       "requires": {
         "@bitgo/blake2b": "^3.0.1",
-        "bech32": "0.0.3",
-        "bigi": "^1.4.0",
-        "bip66": "^1.1.0",
         "bitcoin-ops": "^1.3.0",
+        "bitcoinjs-lib": "git+https://github.com/BitGo/bitcoinjs-lib.git#19fd098772",
         "bs58check": "^2.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "debug": "~3.1.0",
-        "ecurve": "^1.0.0",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "secp256k1": "^3.5.2",
         "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
-        "wif": "^2.0.1"
+        "varuint-bitcoin": "^1.0.4"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "optional": true
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        },
+        "bitcoinjs-lib": {
+          "version": "git+https://github.com/BitGo/bitcoinjs-lib.git#19fd098772fa52ed9f3474b65b3f8fc44d8b5391",
+          "from": "git+https://github.com/BitGo/bitcoinjs-lib.git#19fd098772",
+          "requires": {
+            "bech32": "^2.0.0",
+            "bip174": "^2.0.1",
+            "bip32": "^2.0.4",
+            "bip66": "^1.1.0",
+            "bitcoin-ops": "^1.4.0",
+            "bs58check": "^2.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.3",
+            "merkle-lib": "^2.0.10",
+            "pushdata-bitcoin": "^1.0.1",
+            "randombytes": "^2.0.1",
+            "tiny-secp256k1": "^1.1.6",
+            "typeforce": "^1.11.3",
+            "varuint-bitcoin": "^1.0.4",
+            "wif": "^2.0.1"
+          }
         },
         "bs58": {
           "version": "4.0.1",
@@ -1475,44 +1506,20 @@
             "create-hash": "^1.1.0",
             "safe-buffer": "^5.1.2"
           }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
         }
       }
     },
     "@celo/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@celo/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-El1OZzs36ZPf/cdIZ/Tytk450s6Q6HWWkHPXGbze5Mb6qDpd8azud7PhXT92d/Jp3x1syPxij8kVIIpqo959uw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@celo/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-59bBpcdlg3Y1Ak7gtusTJn91jcRk92IaOBq+uzvCWnvYbRedPUvJkbgqnLdqMlpf0QvY/F9HO8rdpBLPW/QjLg=="
     },
     "@celo/connect": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@celo/connect/-/connect-1.2.4.tgz",
-      "integrity": "sha512-the4Uv/d3rbvYW6EaKwj3OfvrhrbZgZefLH27QsT8FhwDLbNVV9ARVDKVigcW77ZDbwAyMDhwCYWxm47zftJpA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@celo/connect/-/connect-1.2.5.tgz",
+      "integrity": "sha512-Mg4Ul5mocMA39Zdw5ZzUk7PdyapuRN6WN7/i611sZgNs23TO8SbW7Hfal+oZAyZR/4weOSwejZoUQ/yR1cXF3w==",
       "requires": {
-        "@celo/utils": "1.2.4",
+        "@celo/utils": "1.2.5",
         "@types/debug": "^4.1.5",
         "@types/utf8": "^2.1.6",
         "bignumber.js": "^9.0.0",
@@ -1536,21 +1543,21 @@
       }
     },
     "@celo/contractkit": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-1.2.4.tgz",
-      "integrity": "sha512-JciCKqU1xd9Me7ROnIWde4CVOO+jJSK0mAre2RIE07XG6bt77RfIjkioX56YSoxSsm/ulqLWS5bC2mJgCl7iTg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-1.2.5.tgz",
+      "integrity": "sha512-TaCMP2MigmkV/+ysSYgp0Xy8zmxJoZrIQn2gZdBtmszaBmmp3c+up8FbmLj4fkkvK8W+ZtvMiMJJKH1e3hStOw==",
       "requires": {
-        "@celo/base": "1.2.4",
-        "@celo/connect": "1.2.4",
-        "@celo/utils": "1.2.4",
-        "@celo/wallet-local": "1.2.4",
+        "@celo/base": "1.2.5",
+        "@celo/connect": "1.2.5",
+        "@celo/utils": "1.2.5",
+        "@celo/wallet-local": "1.2.5",
         "@types/debug": "^4.1.5",
         "bignumber.js": "^9.0.0",
         "cross-fetch": "3.0.4",
         "debug": "^4.1.1",
         "fp-ts": "2.1.1",
         "io-ts": "2.0.1",
-        "moment": "^2.29.0",
+        "semver": "^7.3.5",
         "web3": "1.3.6"
       },
       "dependencies": {
@@ -1562,24 +1569,27 @@
             "ms": "2.1.2"
           }
         },
-        "moment": {
-          "version": "2.29.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
     "@celo/utils": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-1.2.4.tgz",
-      "integrity": "sha512-FaO70pCWOsPp9MK0A+hUEGLycmqclzywexjvQfmi3KAE+5hy1zlgCmzIgigAkNanYlnbsLhrf/Gro0AVT9RBCQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-1.2.5.tgz",
+      "integrity": "sha512-21Ays/8sqJNblU6gowsNmSnSxitNgx7nHe37dYWgtFXoUHFWQLF1J+SRVBjM55+4oVl6QpaH9cQjbEbLcCdD3Q==",
       "requires": {
-        "@celo/base": "1.2.4",
+        "@celo/base": "1.2.5",
         "@types/country-data": "^0.0.0",
         "@types/elliptic": "^6.4.9",
         "@types/ethereumjs-util": "^5.2.0",
@@ -1696,13 +1706,13 @@
       }
     },
     "@celo/wallet-base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@celo/wallet-base/-/wallet-base-1.2.4.tgz",
-      "integrity": "sha512-gZapmCg9wzIngCI/woE1yoA9Oeu0oTrXetmnHiBTTZYBuFAeCn+u3asF/qnBUVz/NV6aoGvXM+QZJlDWlx4fJw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@celo/wallet-base/-/wallet-base-1.2.5.tgz",
+      "integrity": "sha512-6I7OdV2EbIkajgZNNDGm/R7SQBfIXrDJJyLQ37V0aV4SwVmYTx7GcP+9StuSccqSyAfdw0oy7fMolN+V70x0QA==",
       "requires": {
-        "@celo/base": "1.2.4",
-        "@celo/connect": "1.2.4",
-        "@celo/utils": "1.2.4",
+        "@celo/base": "1.2.5",
+        "@celo/connect": "1.2.5",
+        "@celo/utils": "1.2.5",
         "@types/debug": "^4.1.5",
         "@types/ethereumjs-util": "^5.2.0",
         "bignumber.js": "^9.0.0",
@@ -1746,13 +1756,13 @@
       }
     },
     "@celo/wallet-local": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@celo/wallet-local/-/wallet-local-1.2.4.tgz",
-      "integrity": "sha512-cM5vPRhrZJN/LSB4FX//GAmp5KVLCgKx8EzPseKDb0pLMo0kbjXISI4wHzHdyoMB3ODvw5P91svg4NfZ6fOBvw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@celo/wallet-local/-/wallet-local-1.2.5.tgz",
+      "integrity": "sha512-u2AJo7U3wc15Ym4q+4Ir6NJg2MLq6qFoeFfNdrQifY6Cni6YAWJYQHGmnJV7xOXvNcog9kQeJIMO3ioWQf3LlA==",
       "requires": {
-        "@celo/connect": "1.2.4",
-        "@celo/utils": "1.2.4",
-        "@celo/wallet-base": "1.2.4",
+        "@celo/connect": "1.2.5",
+        "@celo/utils": "1.2.5",
+        "@celo/wallet-base": "1.2.5",
         "@types/ethereumjs-util": "^5.2.0",
         "eth-lib": "^0.2.8",
         "ethereumjs-util": "^5.2.0"
@@ -2005,18 +2015,18 @@
       }
     },
     "@ethereumjs/common": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.4.0.tgz",
-      "integrity": "sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.5.0.tgz",
+      "integrity": "sha512-DEHjW6e38o+JmB/NO3GZBpW4lpaiBpkFgXF6jLcJ6gETBYpEyaA5nTimsWBUJR3Vmtm/didUEbNjajskugZORg==",
       "requires": {
         "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.0"
+        "ethereumjs-util": "^7.1.1"
       },
       "dependencies": {
         "ethereumjs-util": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
-          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.1.tgz",
+          "integrity": "sha512-1CGBmCp3m8IMGHhAJF/icH8qjCJrfQtaZ9KW+cAVV8kyN5Lc1IRq3KjV77ILOutrCwiyf5y2gMyCrAUMoCf2Ag==",
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
@@ -2029,18 +2039,18 @@
       }
     },
     "@ethereumjs/tx": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.3.0.tgz",
-      "integrity": "sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.3.1.tgz",
+      "integrity": "sha512-DXcBdW4upjU11FGlGBAMJw4jXAveL1Siu/8t9jfJ90dehOmpCyGTGWXr6tFzN8663Et8UFLcw3IdV7JJt88iZw==",
       "requires": {
-        "@ethereumjs/common": "^2.4.0",
-        "ethereumjs-util": "^7.1.0"
+        "@ethereumjs/common": "^2.5.0",
+        "ethereumjs-util": "^7.1.1"
       },
       "dependencies": {
         "ethereumjs-util": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
-          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.1.tgz",
+          "integrity": "sha512-1CGBmCp3m8IMGHhAJF/icH8qjCJrfQtaZ9KW+cAVV8kyN5Lc1IRq3KjV77ILOutrCwiyf5y2gMyCrAUMoCf2Ag==",
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
@@ -2124,9 +2134,9 @@
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
-      "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
+      "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -2174,9 +2184,9 @@
       },
       "dependencies": {
         "@ethersproject/abi": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
-          "integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+          "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
           "requires": {
             "@ethersproject/address": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -2255,9 +2265,9 @@
       }
     },
     "@ethersproject/logger": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+      "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A=="
     },
     "@ethersproject/networks": {
       "version": "5.4.2",
@@ -2277,17 +2287,17 @@
       }
     },
     "@ethersproject/properties": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
-      "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+      "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
       "requires": {
         "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.3.tgz",
-      "integrity": "sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
+      "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -2473,16 +2483,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.4.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-          "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+          "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
         }
       }
     },
     "@hashgraph/cryptography": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.0.19.tgz",
-      "integrity": "sha512-ji0+4IB3wPYbU4mY6J6sg1dQWx5KHsOPcbO7udAZKJVa9TBCjlRx9NeZuvQtZ4McN38XgD2UL4Hjg5C5sDwbTg==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.0.20.tgz",
+      "integrity": "sha512-rdKKnENJfs0gsqAtY+7nzpG9TQshtnf+F3/PdH8z+qdy4mo4RSULBMc55FkWWNZLnoA4/34wEW8kohjFEzsLRA==",
       "requires": {
         "@types/crypto-js": "^4.0.2",
         "@types/utf8": "^3.0.0",
@@ -2508,21 +2518,21 @@
       }
     },
     "@hashgraph/proto": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.1.8.tgz",
-      "integrity": "sha512-SCKw45a7rX99o6szdB2orJzVSRfTMHNNiTb7FPxOGXyEnXilIjng7S33aMxS9Q34xQLU/fDBrkWiSpn1boZybg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.0.0.tgz",
+      "integrity": "sha512-SgvtrTgZXpAk9c8LuOoOEs4RNqmSZX8/fYu8oDcqpRxAi5mnyChCkLcSneOyWPDJZmaEV1mz+HeO1HJAJUURAw==",
       "requires": {
         "protobufjs": "^6.11.2"
       }
     },
     "@hashgraph/sdk": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.0.27.tgz",
-      "integrity": "sha512-9BSv84+UJa3zd5p3xOtNIAGa/AgTfewh99hrSia3RwwtsxmsoJ60GdLW3AQTb+9xomPQKJ9UulMpnxxCXf47jg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.1.0.tgz",
+      "integrity": "sha512-YHB3WLExpZPrbDC+1QxD0Q22kmHDXZ25+Bi5QRWH3cDAldL20LR/vY5KKAce2dZMF6Igt4W/cyZx29cQCvKqSQ==",
       "requires": {
         "@grpc/grpc-js": "^1.3.4",
-        "@hashgraph/cryptography": "^1.0.18",
-        "@hashgraph/proto": "1.1.8",
+        "@hashgraph/cryptography": "^1.0.20",
+        "@hashgraph/proto": "2.0.0",
         "@types/crypto-js": "^4.0.2",
         "@types/utf8": "^3.0.0",
         "bignumber.js": "^9.0.1",
@@ -3611,9 +3621,9 @@
       }
     },
     "@open-rpc/client-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@open-rpc/client-js/-/client-js-1.7.0.tgz",
-      "integrity": "sha512-cRGJbXTgdhJNU49vWzJIATRmKBLP2x6tuHJzX9Jg3N8f1VEkge0riUEek2LFIrZiM4TdUp8XV4Ns1W0SZzdfSw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@open-rpc/client-js/-/client-js-1.7.1.tgz",
+      "integrity": "sha512-DycSYZUGSUwFl+k9T8wLBSGA8f2hYkvS5A9AB94tBOuU8QlP468NS5ZtAxy72dF4g2WW0genwNJdfeFnHnaxXQ==",
       "requires": {
         "isomorphic-fetch": "^3.0.0",
         "isomorphic-ws": "^4.0.1",
@@ -3622,9 +3632,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
         }
       }
     },
@@ -3779,13 +3789,30 @@
       "integrity": "sha1-poLV+USOlQ4JnlN+b3L8lgJ10VE="
     },
     "@stacks/common": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-1.2.2.tgz",
-      "integrity": "sha512-knCqq88EBRCN8AhS7+Sx2PJuRv0EFNChEpqLqCAchCHCQfp5bWad/47Zw+fLP9ccBwFXh4pl1wDtbQLBfDo0+A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-2.0.1.tgz",
+      "integrity": "sha512-PXU3Niimk7WK6Q2uetPZmwGhCXIc1u8RBZWvHKYe4dZxdDgT0QLX+eNAui591lsPWOH4ZkhpgSyWtJrtM9hU8g==",
       "requires": {
-        "cross-fetch": "^3.0.6"
+        "@types/node": "^14.14.43",
+        "bn.js": "^5.2.0",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^3.1.4"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "14.17.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.19.tgz",
+          "integrity": "sha512-jjYI6NkyfXykucU6ELEoT64QyKOdvaA6enOqKtP4xUsGY0X0ZUZz29fUmrTRo+7v7c6TgDu82q3GHHaCEkqZwA=="
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "cross-fetch": {
           "version": "3.1.4",
           "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
@@ -3807,25 +3834,48 @@
       "integrity": "sha512-xcWwuRrLJn9qqi3PEBcP2UPZHQztTZd31C0aVlzYHttNMir/sY9SrUqSnw45z2Jo4O9pIYYPIiPRtdV91Ho3fw==",
       "requires": {
         "@stacks/common": "^1.2.2"
+      },
+      "dependencies": {
+        "@stacks/common": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@stacks/common/-/common-1.2.2.tgz",
+          "integrity": "sha512-knCqq88EBRCN8AhS7+Sx2PJuRv0EFNChEpqLqCAchCHCQfp5bWad/47Zw+fLP9ccBwFXh4pl1wDtbQLBfDo0+A==",
+          "requires": {
+            "cross-fetch": "^3.0.6"
+          }
+        },
+        "cross-fetch": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+          "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+          "requires": {
+            "node-fetch": "2.6.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
       }
     },
     "@stacks/transactions": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-1.4.1.tgz",
-      "integrity": "sha512-7LFA9yQqlmN+oVJeYaj+NfZyuInJxF8ozJ8kypCmJ9rUrbbGC/es1KyseB96YBiiOh4eLUfRlD1j6boSdNR8aA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-2.0.1.tgz",
+      "integrity": "sha512-q+8nCbn+0m1T8NbGG2sfMcBcCxdaH/F+vgBEHkhMIFHFLYXVYBGYbTX2llGS9StLp/tQq6p2Bfb1kzKFSw8FRQ==",
       "requires": {
-        "@stacks/common": "^1.2.2",
+        "@stacks/common": "^2.0.1",
         "@stacks/network": "^1.2.2",
         "@types/bn.js": "^4.11.6",
         "@types/elliptic": "^6.4.12",
+        "@types/node": "^14.14.43",
         "@types/randombytes": "^2.0.0",
         "@types/sha.js": "^2.4.0",
-        "bn.js": "^4.11.9",
-        "c32check": "^1.1.1",
-        "cross-fetch": "^3.0.5",
-        "elliptic": "^6.5.3",
+        "bn.js": "^4.12.0",
+        "c32check": "^1.1.2",
+        "cross-fetch": "^3.1.4",
+        "elliptic": "^6.5.4",
         "lodash": "^4.17.20",
-        "lodash-es": "4.17.20",
         "randombytes": "^2.1.0",
         "ripemd160-min": "^0.0.6",
         "sha.js": "^2.4.11",
@@ -3839,6 +3889,11 @@
           "requires": {
             "@types/node": "*"
           }
+        },
+        "@types/node": {
+          "version": "14.17.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.19.tgz",
+          "integrity": "sha512-jjYI6NkyfXykucU6ELEoT64QyKOdvaA6enOqKtP4xUsGY0X0ZUZz29fUmrTRo+7v7c6TgDu82q3GHHaCEkqZwA=="
         },
         "bn.js": {
           "version": "4.12.0",
@@ -4106,9 +4161,9 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "@types/lodash": {
-      "version": "4.14.172",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+      "version": "4.14.174",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.174.tgz",
+      "integrity": "sha512-KMBLT6+g9qrGXpDt7ohjWPUD34WA/jasrtjTEHStF0NPdEwJ1N9SZ+4GaMVDeuk/y0+X5j9xFm6mNiXS7UoaLQ=="
     },
     "@types/long": {
       "version": "4.0.1",
@@ -4177,18 +4232,18 @@
       "dev": true
     },
     "@types/superagent": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.12.tgz",
-      "integrity": "sha512-1GQvD6sySQPD6p9EopDFI3f5OogdICl1sU/2ij3Esobz/RtL9fWZZDPmsuv7eiy5ya+XNiPAxUcI3HIUTJa+3A==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.13.tgz",
+      "integrity": "sha512-YIGelp3ZyMiH0/A09PMAORO0EBGlF5xIKfDpK74wdYvWUs2o96b5CItJcWPdH409b7SAXIIG6p8NdU/4U2Maww==",
       "requires": {
         "@types/cookiejar": "*",
         "@types/node": "*"
       }
     },
     "@types/urijs": {
-      "version": "1.19.16",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.16.tgz",
-      "integrity": "sha512-WgxqcUSEYijGnNWHSln/uqay+AywS3mEhLC+d2PwLsru2fLeMblvxP67Y/SCfB2Pxe+dX/zbIoNNzXY+VKOtNA=="
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.17.tgz",
+      "integrity": "sha512-ShIlp+8iNGo/yVVfYFoNRqUiaE9wMCzsSl85qTg2/C5l56BTJokU7QeMgVBQ9xhcyhWQP0zGXPBZPPvEG/sRmQ=="
     },
     "@types/utf8": {
       "version": "2.1.6",
@@ -4506,9 +4561,9 @@
       }
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -5410,9 +5465,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -5482,9 +5537,9 @@
       }
     },
     "available-typed-arrays": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
-      "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -5497,11 +5552,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axobject-query": {
@@ -6730,9 +6785,9 @@
       "integrity": "sha512-O+K1w8P/aAOLcYwwQ4sbiPYZ51ZIW95lnS4/6nE8Aib/z+OOddQIIPdu2qi94qGDp4HhYy/wJotttXKkak1lXg=="
     },
     "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw=="
     },
     "big.js": {
       "version": "3.2.0",
@@ -6778,6 +6833,11 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "bip174": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
+      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
     },
     "bip32": {
       "version": "2.0.6",
@@ -6842,6 +6902,53 @@
       "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
+    "bitcoinjs-lib": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
+      "integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
+      "requires": {
+        "bech32": "^1.1.2",
+        "bip174": "^2.0.1",
+        "bip32": "^2.0.4",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "tiny-secp256k1": "^1.1.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "bs58check": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+          "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+          "requires": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
+    },
     "bitcoinjs-message": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.2.0.tgz",
@@ -6901,14 +7008,16 @@
       }
     },
     "bitgo": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/bitgo/-/bitgo-12.0.0.tgz",
-      "integrity": "sha512-VUsh/0ccCwvpawhS4NTZDZi3B2bpmdnLRnqlvwHVXwQx8qLcBgkFJMqNynHHtcNY3PCdJapmA32o+mefucFA6A==",
+      "version": "12.1.0-rc.11",
+      "resolved": "https://registry.npmjs.org/bitgo/-/bitgo-12.1.0-rc.11.tgz",
+      "integrity": "sha512-ABvQW62NR0ATjzVga89jMmgXnmMbw6l/G5HIOMtmWoy171JNMR7b4QNHGeRbJDLBc1DA7qfk5JpZOtkSSK5S4g==",
       "requires": {
-        "@bitgo/account-lib": "^2.15.0",
-        "@bitgo/statics": "^6.12.0",
+        "@bitgo/account-lib": "^2.16.0-rc.12",
+        "@bitgo/statics": "^6.13.0-rc.7",
         "@bitgo/unspents": "^0.6.0",
-        "@bitgo/utxo-lib": "^1.9.6",
+        "@bitgo/utxo-lib": "^1.10.0-rc.10",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
         "@types/bluebird": "^3.5.25",
         "@types/superagent": "^4.1.3",
         "algosdk": "git+https://github.com/BitGo/algosdk-bitgo.git",
@@ -6928,7 +7037,6 @@
         "eosjs": "^16.0.8",
         "eosjs-ecc": "^4.0.4",
         "ethereumjs-abi": "^0.6.5",
-        "ethereumjs-tx": "^1.3.7",
         "ethereumjs-util": "^4.4.1",
         "lodash": "^4.17.14",
         "moment": "^2.20.1",
@@ -7074,9 +7182,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
-          "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
+          "version": "12.20.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.27.tgz",
+          "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg=="
         }
       }
     },
@@ -7531,9 +7639,9 @@
       "dev": true
     },
     "bufferutil": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
-      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.4.tgz",
+      "integrity": "sha512-VNxjXUCrF3LvbLgwfkTb5LsFvk6pGIn7OBb9x+3o+iJ6mKw0JTUp4chBFc88hi1aspeZGeZG9jAIbpFYPQSLZw==",
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -7973,27 +8081,46 @@
         "webpack": "^5.24.3"
       },
       "dependencies": {
-        "browserslist": {
-          "version": "4.16.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-          "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
-            "caniuse-lite": "^1.0.30001248",
-            "colorette": "^1.2.2",
-            "electron-to-chromium": "^1.3.793",
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "browserslist": {
+          "version": "4.17.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+          "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001259",
+            "electron-to-chromium": "^1.3.846",
             "escalade": "^3.1.1",
-            "node-releases": "^1.1.73"
+            "nanocolors": "^0.1.5",
+            "node-releases": "^1.1.76"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001249",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-          "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw=="
+          "version": "1.0.30001260",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+          "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+          "requires": {
+            "nanocolors": "^0.1.0"
+          }
         },
         "electron-to-chromium": {
-          "version": "1.3.802",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz",
-          "integrity": "sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg=="
+          "version": "1.3.850",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.850.tgz",
+          "integrity": "sha512-ZzkDcdzePeF4dhoGZQT77V2CyJOpwfTZEOg4h0x6R/jQhGt/rIRpbRyVreWLtD7B/WsVxo91URm2WxMKR9JQZA=="
         },
         "has-flag": {
           "version": "4.0.0",
@@ -8001,14 +8128,19 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-worker": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-          "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+          "version": "27.2.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.2.tgz",
+          "integrity": "sha512-aG1xq9KgWB2CPC8YdMIlI8uZgga2LFNcGbHJxO8ctfXAydSaThR4EewKQGg3tBOC+kS3vhPGgymsBdi9VINjPw==",
           "requires": {
             "@types/node": "*",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           }
+        },
+        "node-releases": {
+          "version": "1.1.76",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+          "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA=="
         },
         "p-limit": {
           "version": "3.1.0",
@@ -8026,6 +8158,15 @@
             "randombytes": "^2.1.0"
           }
         },
+        "source-map-support": {
+          "version": "0.5.20",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+          "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -8034,23 +8175,52 @@
             "has-flag": "^4.0.0"
           }
         },
-        "terser-webpack-plugin": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-          "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+        "terser": {
+          "version": "5.9.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+          "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
           "requires": {
-            "jest-worker": "^27.0.2",
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.20"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+            }
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
+          "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
+          "requires": {
+            "jest-worker": "^27.0.6",
             "p-limit": "^3.1.0",
-            "schema-utils": "^3.0.0",
+            "schema-utils": "^3.1.1",
             "serialize-javascript": "^6.0.0",
             "source-map": "^0.6.1",
-            "terser": "^5.7.0"
+            "terser": "^5.7.2"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+              "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+              "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+              }
+            }
           }
         },
         "webpack": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.50.0.tgz",
-          "integrity": "sha512-hqxI7t/KVygs0WRv/kTgUW8Kl3YC81uyWQSo/7WUs5LsuRw0htH/fCwbVBGCuiX/t4s7qzjXFcf41O8Reiypag==",
+          "version": "5.54.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.54.0.tgz",
+          "integrity": "sha512-MAVKJMsIUotOQKzFOmN8ZkmMlj7BOyjDU6t1lomW9dWOme5WTStzGa3HMLdV1KYD1AiFETGsznL4LMSvj4tukw==",
           "requires": {
             "@types/eslint-scope": "^3.7.0",
             "@types/estree": "^0.0.50",
@@ -8061,8 +8231,8 @@
             "acorn-import-assertions": "^1.7.6",
             "browserslist": "^4.14.5",
             "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.8.0",
-            "es-module-lexer": "^0.7.1",
+            "enhanced-resolve": "^5.8.3",
+            "es-module-lexer": "^0.9.0",
             "eslint-scope": "5.1.1",
             "events": "^3.2.0",
             "glob-to-regexp": "^0.4.1",
@@ -8506,7 +8676,8 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
     },
     "colors": {
       "version": "1.0.3",
@@ -10342,9 +10513,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-      "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -10560,9 +10731,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-      "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.0.tgz",
+      "integrity": "sha512-qU2eN/XHsrl3E4y7mK1wdWnyy5c8gXtCbfP6Xcsemm7fPUR1PIV1JhZfP7ojcN0Fzp69CfrS3u76h2tusvfKiQ=="
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -11212,12 +11383,6 @@
         }
       }
     },
-    "ethereum-common": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
-      "optional": true
-    },
     "ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
@@ -11304,34 +11469,39 @@
       "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
     },
     "ethereumjs-tx": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "optional": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
+        "ethereumjs-common": "^1.5.0",
+        "ethereumjs-util": "^6.0.0"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "optional": true
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "optional": true,
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "requires": {
+            "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
             "elliptic": "^6.5.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
           }
         }
       }
@@ -11405,17 +11575,17 @@
       }
     },
     "ethers": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.4.tgz",
-      "integrity": "sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
       "requires": {
-        "@ethersproject/abi": "5.4.0",
+        "@ethersproject/abi": "5.4.1",
         "@ethersproject/abstract-provider": "5.4.1",
         "@ethersproject/abstract-signer": "5.4.1",
         "@ethersproject/address": "5.4.0",
         "@ethersproject/base64": "5.4.0",
         "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
+        "@ethersproject/bignumber": "5.4.2",
         "@ethersproject/bytes": "5.4.0",
         "@ethersproject/constants": "5.4.0",
         "@ethersproject/contracts": "5.4.1",
@@ -11423,11 +11593,11 @@
         "@ethersproject/hdnode": "5.4.0",
         "@ethersproject/json-wallets": "5.4.0",
         "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.0",
+        "@ethersproject/logger": "5.4.1",
         "@ethersproject/networks": "5.4.2",
         "@ethersproject/pbkdf2": "5.4.0",
-        "@ethersproject/properties": "5.4.0",
-        "@ethersproject/providers": "5.4.3",
+        "@ethersproject/properties": "5.4.1",
+        "@ethersproject/providers": "5.4.5",
         "@ethersproject/random": "5.4.0",
         "@ethersproject/rlp": "5.4.0",
         "@ethersproject/sha2": "5.4.0",
@@ -11442,9 +11612,9 @@
       },
       "dependencies": {
         "@ethersproject/abi": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
-          "integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+          "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
           "requires": {
             "@ethersproject/address": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -11696,11 +11866,11 @@
       }
     },
     "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "requires": {
-        "type": "^2.0.0"
+        "type": "^2.5.0"
       },
       "dependencies": {
         "type": {
@@ -12725,6 +12895,15 @@
         "pump": "^3.0.0"
       }
     },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "get-uri": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
@@ -12947,9 +13126,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.22.tgz",
-      "integrity": "sha512-lzEllxWc05n/HEv75SsDrA7zdEVvQzTZimItZm/TZ5XBs7cmx2NJmSlA5I0kZbdKNu8GFETBhSpo+SOhx0JslA=="
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.23.tgz",
+      "integrity": "sha512-bcrAEAF68R5p3ooGytNTPEJ4eSOg5QJ9wiBoENRrqIiSPvllIenQq/e7+H5GleOIDSJvrLZZPF8oicPUEFi5Rg=="
     },
     "got": {
       "version": "9.6.0",
@@ -14200,11 +14379,11 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.7.tgz",
-      "integrity": "sha512-VxlpTBGknhQ3o7YiVjIhdLU6+oD8dPz/79vvvH4F+S/c8608UCVa9fgDpa1kZgFoUST2DCgacc70UszKgzKuvA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
       "requires": {
-        "available-typed-arrays": "^1.0.4",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
@@ -14212,27 +14391,50 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
             "string.prototype.trimend": "^1.0.4",
             "string.prototype.trimstart": "^1.0.4",
             "unbox-primitive": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "requires": {
+            "has-tostringtag": "^1.0.0"
           }
         },
         "object-inspect": {
@@ -14300,14 +14502,36 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+          "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "whatwg-fetch": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
           "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -16064,9 +16288,9 @@
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-base64": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
-      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-sha3": {
       "version": "0.5.7",
@@ -16109,9 +16333,9 @@
       }
     },
     "jsbi": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.1.6.tgz",
-      "integrity": "sha512-CGjq13y28FrBA5mAU+rsfHaVKEF9jrw3PhzZpIzTeMiPsT0XRDAS6E7QS8/ZTmFQUtl2MDJsxKQoYJzAhF7B1w=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.4.tgz",
+      "integrity": "sha512-iOygwxPzMYli5xrjfd83Vy4Wyu9Ovpw6wWWFy5Kj7XP+pZxPp7Cy72F92iAt2j+6tTDYunvLtC+2tH3xCX37ng=="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -16364,12 +16588,13 @@
       }
     },
     "keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
       "requires": {
         "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "keccak256": {
@@ -16634,11 +16859,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash-es": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
-      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
-    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
@@ -16758,7 +16978,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -17428,6 +17647,11 @@
       "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
       "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
     },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -17533,9 +17757,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -17672,7 +17896,8 @@
     "node-releases": {
       "version": "1.1.73",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -18806,9 +19031,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.4.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-          "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+          "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
         }
       }
     },
@@ -20087,9 +20312,9 @@
       }
     },
     "ripple-lib": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.9.8.tgz",
-      "integrity": "sha512-86wAP4GD6ZVMHIZeqrzn9m8BZSWSpMr06ULaAKNZbN6mxvh7SwcabJjcINRZNpI73Sb3oibWoOsCQ+Vf64WSTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.0.tgz",
+      "integrity": "sha512-Cg2u73UybfM1PnzcuLt5flvLKZn35ovdIp+1eLrReVB4swuRuUF/SskJG9hf5wMosbvh+E+jZu8A6IbYJoyFIA==",
       "requires": {
         "@types/lodash": "^4.14.136",
         "@types/ws": "^7.2.0",
@@ -20150,9 +20375,9 @@
           }
         },
         "ws": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
         }
       }
     },
@@ -20601,42 +20826,18 @@
         "postcss": "^7.0.27"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
+        "nanocolors": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.10.tgz",
+          "integrity": "sha512-i+EDWGsJClQwR/bhLIG/CObZZwaYaS5qt+yjxZbfV+77QiNHNzE9nj4d9Ut1TGZ0R0eSwPcQWzReASzXuw/7oA=="
         },
         "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+          "version": "7.0.38",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.38.tgz",
+          "integrity": "sha512-wNrSHWjHDQJR/IZL5IKGxRtFgrYNaAA/UrkW2WqbtZO6uxSLMxMN+s2iqUMwnAWm3fMROlDYZB41dr0Mt7vBwQ==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
+            "nanocolors": "^0.2.2",
+            "source-map": "^0.6.1"
           }
         }
       }
@@ -21521,9 +21722,9 @@
       "dev": true
     },
     "stellar-base": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-5.3.2.tgz",
-      "integrity": "sha512-KZizceCz15oqwKdNRMfHtBGsCBv4Xea1kOUxgMqQ0TU/HFUg3Vu78rzTZsRWdU7qrG48yJWdwm8R1dWjVL+LRw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-6.0.3.tgz",
+      "integrity": "sha512-3xQo7VU2u84CQZ4ZxOk+TVXAUuMkwNbWzMcUSEcYja5i5CRX1RK1ivP9pn/VENIsLgu5tWhQeBMt3WHOo1ryBw==",
       "requires": {
         "base32.js": "^0.1.0",
         "bignumber.js": "^4.0.0",
@@ -21548,9 +21749,9 @@
       }
     },
     "stellar-sdk": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-8.2.5.tgz",
-      "integrity": "sha512-w10LVJE/0Ug5ymw7IR4mibNtHWZNJcaIlMEdyUIgMwCnrxYKPT6VSUCCRHYEemAR2fDzi2ZOKql1mxq2sMOV8Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-8.3.0.tgz",
+      "integrity": "sha512-yaeyoCjNE3OqOKktOGxPd2OqcE7vWx/5suPgmcDAqdjLLZgMw6o5W6jd0UyjpKmUQX3P0cXrMZLYJg+G/2qy+w==",
       "requires": {
         "@types/eventsource": "^1.1.2",
         "@types/node": ">= 8",
@@ -21563,13 +21764,21 @@
         "eventsource": "^1.0.7",
         "lodash": "^4.17.11",
         "randombytes": "^2.1.0",
-        "stellar-base": "^5.3.2",
+        "stellar-base": "^6.0.3",
         "toml": "^2.3.0",
         "tslib": "^1.10.0",
         "urijs": "^1.19.1",
         "utility-types": "^3.7.0"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
         "bignumber.js": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
@@ -22078,14 +22287,14 @@
       }
     },
     "tapable": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-      "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "tar": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.16.tgz",
-      "integrity": "sha512-gOVUT/KWPkGFZQmCRDVFNUWBl7niIo/PRR7lzrIqtZpit+st54lGROuVjc6zEQM9FhH+dJfQIl+9F0k8GNXg5g==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "requires": {
         "chownr": "^1.1.4",
         "fs-minipass": "^1.2.7",
@@ -22159,6 +22368,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
       "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "dev": true,
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -22168,7 +22378,8 @@
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
         }
       }
     },
@@ -22798,9 +23009,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -23192,9 +23403,9 @@
       "dev": true
     },
     "utf-8-validate": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
-      "integrity": "sha512-+pnxRYsS/axEpkrrEpzYfNZGXp0IjC/9RIxwM5gntY4Koi8SHmUGSfxfWqxZdRxrtaoVstuOzUp/rbs3JSPELQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.6.tgz",
+      "integrity": "sha512-hoY0gOf9EkCw+nimK21FVKHUIG1BMqSiRwxB/q3A9yKZOrOI99PP77BxmarDqWz6rG3vVYiBWfhG8z2Tl+7fZA==",
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -23846,9 +24057,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
-          "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
+          "version": "12.20.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.27.tgz",
+          "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg=="
         },
         "underscore": {
           "version": "1.12.1",
@@ -23880,9 +24091,9 @@
           }
         },
         "@types/node": {
-          "version": "12.20.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
-          "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
+          "version": "12.20.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.27.tgz",
+          "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg=="
         }
       }
     },
@@ -24030,42 +24241,6 @@
         "web3-utils": "1.3.6"
       },
       "dependencies": {
-        "@types/bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-          "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        },
         "underscore": {
           "version": "1.12.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
@@ -24157,9 +24332,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
-          "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
+          "version": "12.20.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.27.tgz",
+          "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg=="
         }
       }
     },
@@ -25562,9 +25737,9 @@
       }
     },
     "webpack-sources": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
-      "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
+      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA=="
     },
     "websocket": {
       "version": "1.0.34",
@@ -25663,40 +25838,63 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-typed-array": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.6.tgz",
-      "integrity": "sha512-DdY984dGD5sQ7Tf+x1CkXzdg85b9uEel6nr4UkFg1LoE9OXv3uRuZhe5CoWdawhGACeFpEZXH8fFLQnDhbpm/Q==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
       "requires": {
-        "available-typed-arrays": "^1.0.4",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.6"
+        "is-typed-array": "^1.1.7"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
             "string.prototype.trimend": "^1.0.4",
             "string.prototype.trimstart": "^1.0.4",
             "unbox-primitive": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "requires": {
+            "has-tostringtag": "^1.0.0"
           }
         },
         "object-inspect": {
@@ -25973,8 +26171,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "2.8.11",
+  "version": "2.8.13",
   "private": true,
   "main": "resources/electron.js",
   "homepage": "./",
@@ -19,7 +19,7 @@
   "dependencies": {
     "autoprefixer": "8.6.5",
     "bignumber.js": "^9.0.0",
-    "bitgo": "^12.0.0",
+    "bitgo": "^12.1.0-rc.11",
     "bitgo-utxo-lib": "^1.8.0",
     "bootstrap": "^4.3.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",

--- a/resources/package.json
+++ b/resources/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "2.8.11",
+  "version": "2.8.13",
   "private": true,
   "main": "electron.js",
   "homepage": "./",


### PR DESCRIPTION
**Background**

EOS Jungle2.0 testnet got upgraded to EOS Jungle3.0 and in the process, its chain id also got changed. We had not updated this chain id. Because of this, we were facing issues while broadcasting the recovery transaction generated using Wallet Recovery Wizard (Non-Bitgo Recovery) as the chain id is being used in its generation.

**Changes**

- Fixed the issue of non-bitgo recovery of EOS by upgrading the BitGoJS to the latest version.

- Updated documentation for how to power up the eos account for broadcasting tx on the eos network

Ticket: BG-30012