### PR TITLE
fix(wrw): Output xpubs with key derivation info if present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BitGoWalletRecoveryWizard",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "main": "resources/electron.js",
   "homepage": "./",

--- a/resources/package.json
+++ b/resources/package.json
@@ -2,7 +2,7 @@
   "name": "BitGoWalletRecoveryWizard",
   "author": "BitGo, Inc.",
   "description": "A UI-based desktop app for BitGo Recoveries",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "main": "electron.js",
   "homepage": "./",

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,6 +37,16 @@ export function isBlockChairKeyNeeded(coin) {
   return false;
 }
 
+/**
+ * Converts a master xpub to the corresponding derived xpub
+ * @param {BitGo} baseCoin 
+ * @param {string} masterXpub 
+ * @param {string} seed 
+ */
+export function getDerivedXpub(baseCoin, masterXpub, seed) {
+  return baseCoin.deriveKeyWithSeed({ key: masterXpub, seed });
+}
+
 export async function getRecoveryDebugInfo(baseCoin, recoveryParams) {
   if (!coinConfig.supportKeyDerivationForDebugging.includes(baseCoin.getFamily())) {
     return new Error('unsupported coin');


### PR DESCRIPTION
since wallets can be created with user and backup keys
with custom derivation paths, we will need to give info
on which derivation path were used for each key so that
ovc which is only aware of master keys can properly use
the correct derivation path while signing

Ticket: BG-45944