### PR TITLE
fix(wrw): remove bitgo-utxo-lib and blake2b dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1366,11 +1366,6 @@
             "wif": "^2.0.1"
           }
         },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
         "bs58": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -1387,48 +1382,6 @@
             "bs58": "^4.0.0",
             "create-hash": "^1.1.0",
             "safe-buffer": "^5.1.2"
-          }
-        },
-        "ethereumjs-utils-old": {
-          "version": "npm:ethereumjs-util@5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          },
-          "dependencies": {
-            "secp256k1": {
-              "version": "3.8.0",
-              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-              "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-              "requires": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.5.2",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
-              }
-            }
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
           }
         },
         "secp256k1": {
@@ -1630,30 +1583,6 @@
         "varuint-bitcoin": "^1.0.4"
       },
       "dependencies": {
-        "bitcoinjs-lib": {
-          "version": "npm:@bitgo/bitcoinjs-lib@6.1.0-rc.3",
-          "resolved": "https://registry.npmjs.org/@bitgo/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0-rc.3.tgz",
-          "integrity": "sha512-HQa13C61wVtkMKJG+L2Nz7bjuu8N252OHouRd3bFP38Xhlxc0+KX0j0H7KBEjcjYMsknV2Ts51gGLzBltdXvoA==",
-          "requires": {
-            "bech32": "^2.0.0",
-            "bip174": "^2.0.1",
-            "bip32": "^2.0.4",
-            "bip66": "^1.1.0",
-            "bitcoin-ops": "^1.4.0",
-            "bs58check": "^2.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.3",
-            "elliptic": "^6.5.4",
-            "fastpriorityqueue": "^0.7.1",
-            "merkle-lib": "^2.0.10",
-            "pushdata-bitcoin": "^1.0.1",
-            "randombytes": "^2.0.1",
-            "tiny-secp256k1": "^1.1.6",
-            "typeforce": "^1.11.3",
-            "varuint-bitcoin": "^1.0.4",
-            "wif": "^2.0.1"
-          }
-        },
         "bs58": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -7814,9 +7743,9 @@
       }
     },
     "bip174": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
-      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.0.tgz",
+      "integrity": "sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA=="
     },
     "bip32": {
       "version": "2.0.6",
@@ -7880,6 +7809,50 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+    },
+    "bitcoinjs-lib": {
+      "version": "npm:@bitgo/bitcoinjs-lib@6.1.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@bitgo/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0-rc.3.tgz",
+      "integrity": "sha512-HQa13C61wVtkMKJG+L2Nz7bjuu8N252OHouRd3bFP38Xhlxc0+KX0j0H7KBEjcjYMsknV2Ts51gGLzBltdXvoA==",
+      "requires": {
+        "bech32": "^2.0.0",
+        "bip174": "^2.0.1",
+        "bip32": "^2.0.4",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "elliptic": "^6.5.4",
+        "fastpriorityqueue": "^0.7.1",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "tiny-secp256k1": "^1.1.6",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "dependencies": {
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "bs58check": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+          "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+          "requires": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
     },
     "bitcoinjs-message": {
       "version": "2.2.0",
@@ -7993,91 +7966,6 @@
         }
       }
     },
-    "bitgo-utxo-lib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bitgo-utxo-lib/-/bitgo-utxo-lib-1.8.0.tgz",
-      "integrity": "sha512-6FQhml+7PKkR70cF6Kkj0JDKWhJb6czDcxJjyaq12fSKhn1hHjQCS4TrHYVmJuf4JH2xuaANX2Jx6exanTT8fQ==",
-      "requires": {
-        "bech32": "0.0.3",
-        "bigi": "^1.4.0",
-        "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.3.0",
-        "blake2b": "blake2b@git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
-        "bs58check": "^2.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "debug": "~3.1.0",
-        "ecurve": "^1.0.0",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "secp256k1": "^3.5.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
-        "wif": "^2.0.1"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-0.0.3.tgz",
-          "integrity": "sha512-O+K1w8P/aAOLcYwwQ4sbiPYZ51ZIW95lnS4/6nE8Aib/z+OOddQIIPdu2qi94qGDp4HhYy/wJotttXKkak1lXg=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "optional": true
-        },
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "requires": {
-            "base-x": "^3.0.2"
-          }
-        },
-        "bs58check": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-          "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-          "requires": {
-            "bs58": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        }
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -8086,35 +7974,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      }
-    },
-    "blake2b": {
-      "version": "git+ssh://git@github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
-      "from": "blake2b@git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
-      "requires": {
-        "blake2b-wasm": "blake2b-wasm@https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b",
-        "nanoassert": "^1.0.0"
-      },
-      "dependencies": {
-        "nanoassert": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-        }
-      }
-    },
-    "blake2b-wasm": {
-      "version": "git+ssh://git@github.com/BitGo/blake2b-wasm.git#193cdb71656c1a6c7f89b05d0327bb9b758d071b",
-      "from": "blake2b-wasm@https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b",
-      "requires": {
-        "nanoassert": "^1.0.0"
-      },
-      "dependencies": {
-        "nanoassert": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-        }
       }
     },
     "blakejs": {
@@ -12622,6 +12481,53 @@
         }
       }
     },
+    "ethereumjs-utils-old": {
+      "version": "npm:ethereumjs-util@5.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "^0.1.3",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
+    },
     "ethers": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.1.tgz",
@@ -13442,12 +13348,9 @@
       "dev": true
     },
     "fastpriorityqueue": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.1.tgz",
-      "integrity": "sha512-XJ+vbiXYjmxc32VEpXScAq7mBg3vqh90OjLfiuyQ0zAtXpgICdVgGjKHep1kLGQufyuCBiEYpl6ZKcw79chTpA==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.2.tgz",
+      "integrity": "sha512-5DtIKh6vtOmEGkYdEPNNb+mxeYCnBiKbK3s4gq52l6cX8I5QaTDWWw0Wx/iYo80fVOblSycHu1/iJeqeNxG8Jw=="
     },
     "fastq": {
       "version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "autoprefixer": "8.6.5",
     "bignumber.js": "^9.0.0",
     "bitgo": "14.1.0-wrw-hotfix.0",
-    "bitgo-utxo-lib": "^1.8.0",
+    "@bitgo/utxo-lib": "2.2.2-rc.2",
     "bootstrap": "^4.3.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
     "chalk": "2.4.1",

--- a/src/components/migrated-legacy.js
+++ b/src/components/migrated-legacy.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { CoinDropdown, InputField } from './form-components';
 import { Form, Button, Row, Col, Alert } from 'reactstrap';
-import { address, HDNode, Transaction, TransactionBuilder } from 'bitgo-utxo-lib';
+import { address, HDNode, Transaction, TransactionBuilder } from '@bitgo/utxo-lib';
 
 import * as _ from 'lodash';
 

--- a/src/components/unsigned-sweep.js
+++ b/src/components/unsigned-sweep.js
@@ -15,7 +15,7 @@ import { isBlockChairKeyNeeded, recoverWithKeyPath, toWei, getDerivedXpub } from
 const fs = window.require('fs');
 const formTooltips = tooltips.unsignedSweep;
 const { dialog } = window.require('electron').remote;
-const utxoLib = require('bitgo-utxo-lib');
+const utxoLib = require('@bitgo/utxo-lib');
 
 class UnsignedSweep extends Component {
   state = {
@@ -227,7 +227,7 @@ class UnsignedSweep extends Component {
         }
       } else {
         // setting a default gas limit for the transaction as any excess funds which is not utilized for
-        // gas fees will be refunded for the sender. We cannot estimate the actual gas without the data 
+        // gas fees will be refunded for the sender. We cannot estimate the actual gas without the data
         // part of the transaction which should be signed which we cannot get in WRW.
         recoveryParams.gasLimit = 500000;
       }


### PR DESCRIPTION
These dependencies are outdated and cause issues when trying to build
releases.

If I understand correctly, because of the way the package-lock.json has been manually edited, it must be installed with `npm ci` for it to avoid the dependency issues.

Ticket: BG-48164