### PR TITLE
chore(wrw): update sdk to hotfix.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7911,11 +7911,10 @@
           }
         }
       }
-    },
-    "bitgo": {
-      "version": "14.1.0-wrw-hotfix.0",
-      "resolved": "https://registry.npmjs.org/bitgo/-/bitgo-14.1.0-wrw-hotfix.0.tgz",
-      "integrity": "sha512-PdZSv3EWUNGje/Cf23J/vVI4R2m3RcmOAl45BH1lbF0OQWVOacK3tKPltT+2kde+MvBd/4b7enH5ZeIZj9Ry7g==",
+    },"bitgo": {
+      "version": "14.1.0-wrw-hotfix.1",
+      "resolved": "https://registry.npmjs.org/bitgo/-/bitgo-14.1.0-wrw-hotfix.1.tgz",
+      "integrity": "sha512-WvDyuwl0PtvJ4q0NbHrYx0KJhJppCNEexfqDONCSqCo2X3ppUvP0wx/Vfntb/G6jmpc5XdArwKQ366uWoiEkQw==",
       "requires": {
         "@bitgo/account-lib": "^2.19.0-rc.12",
         "@bitgo/blockapis": "^1.0.1-rc.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "autoprefixer": "8.6.5",
     "bignumber.js": "^9.0.0",
-    "bitgo": "14.1.0-wrw-hotfix.0",
+    "bitgo": "14.1.0-wrw-hotfix.1",
     "@bitgo/utxo-lib": "2.2.2-rc.2",
     "bootstrap": "^4.3.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",


### PR DESCRIPTION
The latest version of the SDK includes these two PRs we need to resolve two cross chain recovery issues.
[fix: v1 getWallet call by DariusParvin · Pull Request #2289 · BitGo/BitGoJS](https://github.com/BitGo/BitGoJS/pull/2289) 
[fix(bitgo): getUnspentInfo to handle missing unspents by DariusParvin · Pull Request #2292 · BitGo/BitGoJS](https://github.com/BitGo/BitGoJS/pull/2292)

I've tested this package update (using `npm ci`) on mac and it fixed the issues.

Ticket: BG-48707