### PR TITLE
feat(wrw): add ethw to unsigned-sweep and non-bitgo

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -10,6 +10,7 @@ import { Btg } from '@bitgo/sdk-coin-btg';
 import { Dash } from '@bitgo/sdk-coin-dash';
 import { Eos, Teos } from '@bitgo/sdk-coin-eos';
 import { Erc20Token, Eth, Gteth } from '@bitgo/sdk-coin-eth';
+import { Ethw } from '@bitgo/sdk-coin-ethw';
 import { Ltc } from '@bitgo/sdk-coin-ltc';
 import { Trx, Ttrx } from '@bitgo/sdk-coin-trx';
 import { Txlm, Xlm } from '@bitgo/sdk-coin-xlm';
@@ -53,6 +54,7 @@ sdk.register('btc', Btc.createInstance);
 sdk.register('tbtc', Tbtc.createInstance);
 sdk.register('eth', Eth.createInstance);
 sdk.register('gteth', Gteth.createInstance);
+sdk.register('ethw', Ethw.createInstance)
 sdk.register('eos', Eos.createInstance);
 sdk.register('teos', Teos.createInstance);
 sdk.register('xlm', Xlm.createInstance);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@bitgo/sdk-coin-dash": "^1.1.1",
         "@bitgo/sdk-coin-eos": "^1.0.2",
         "@bitgo/sdk-coin-eth": "^1.1.1",
+        "@bitgo/sdk-coin-ethw": "^1.1.0-rc.3",
         "@bitgo/sdk-coin-ltc": "^1.1.1",
         "@bitgo/sdk-coin-trx": "^1.0.2",
         "@bitgo/sdk-coin-xlm": "^1.0.2",
@@ -2663,6 +2664,244 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/@bitgo/sdk-coin-eth/node_modules/secp256k1": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw": {
+      "version": "1.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-ethw/-/sdk-coin-ethw-1.1.0-rc.7.tgz",
+      "integrity": "sha512-p5Ilv03Vn7xmDZbPWZ3nL4WLp9PLVKo2tpLDQXRqK0gRGefRkIZVCgkw8863A0T4W1YdVQuKe7sJSn5xT9rdpw==",
+      "dependencies": {
+        "@bitgo/abstract-eth": "^1.0.3-rc.19",
+        "@bitgo/sdk-coin-eth": "^2.0.0-rc.15",
+        "@bitgo/sdk-core": "^2.0.0-rc.15",
+        "@bitgo/statics": "^8.0.0-rc.12",
+        "bignumber.js": "^9.0.0",
+        "superagent": "^3.8.3"
+      },
+      "engines": {
+        "node": ">=14 <17"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/abstract-eth": {
+      "version": "1.0.3-rc.19",
+      "resolved": "https://registry.npmjs.org/@bitgo/abstract-eth/-/abstract-eth-1.0.3-rc.19.tgz",
+      "integrity": "sha512-pHvEV35yC0HU2EGKqNXayIOmAOvJqjcO1YHgJef4xaHWLjkJeZzMMh5CLXqx/QeRrAHMtfIQGYHQXchEDzda1g==",
+      "dependencies": {
+        "@bitgo/sdk-coin-eth": "^2.0.0-rc.15",
+        "@bitgo/sdk-core": "^2.0.0-rc.15",
+        "@bitgo/statics": "^8.0.0-rc.12",
+        "@bitgo/utxo-lib": "^3.0.0-rc.4",
+        "bignumber.js": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14 <17"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/abstract-eth/node_modules/bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/blake2b": {
+      "version": "3.0.4-rc.0",
+      "resolved": "https://registry.npmjs.org/@bitgo/blake2b/-/blake2b-3.0.4-rc.0.tgz",
+      "integrity": "sha512-/NVV3MY6szDM6gehfRRVZPQ9EmNVNVdnsWhibx+lgFq27z3UiU0ZCxItH03PGFFXSICRiH9xYb0SCOFm+Qn/uQ==",
+      "dependencies": {
+        "@bitgo/blake2b-wasm": "^3.0.4-rc.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/blake2b-wasm": {
+      "version": "3.0.4-rc.0",
+      "resolved": "https://registry.npmjs.org/@bitgo/blake2b-wasm/-/blake2b-wasm-3.0.4-rc.0.tgz",
+      "integrity": "sha512-HbwX9YpLjUDIDgA1Dp6KgNhrkF06Rplio/3QjVbOdrGcTRfWxKly38l0eHqMnlgIigPjG/UOpCCVBLMzkOkUbA==",
+      "dependencies": {
+        "nanoassert": "^1.0.0"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/blake2b-wasm/node_modules/nanoassert": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+      "integrity": "sha512-C40jQ3NzfkP53NsO8kEOFd79p4b9kDXQMwgiY1z8ZwrDZgUyom0AHwGegF4Dm99L+YoYhuaB0ceerUcXmqr1rQ=="
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/sdk-coin-eth": {
+      "version": "2.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-eth/-/sdk-coin-eth-2.0.0-rc.15.tgz",
+      "integrity": "sha512-Ey1ZpnFw00183076/C0zFyDeAj+eke/LgcojC2Oozv58GHTsb3Hd9gqM3MLIcTQpJsSqDSEp+3gj4eI/S96iAg==",
+      "dependencies": {
+        "@bitgo/sdk-core": "^2.0.0-rc.15",
+        "@bitgo/statics": "^8.0.0-rc.12",
+        "@bitgo/utxo-lib": "^3.0.0-rc.4",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
+        "bignumber.js": "^9.0.0",
+        "bn.js": "^5.2.1",
+        "debug": "^3.1.0",
+        "ethereumjs-abi": "^0.6.5",
+        "ethereumjs-util": "7.1.5",
+        "ethers": "^5.1.3",
+        "keccak": "^3.0.2",
+        "lodash": "^4.17.14",
+        "secp256k1": "4.0.2",
+        "superagent": "^3.8.3"
+      },
+      "engines": {
+        "node": ">=14 <17"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/sdk-core": {
+      "version": "2.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@bitgo/sdk-core/-/sdk-core-2.0.0-rc.15.tgz",
+      "integrity": "sha512-x9TBgoSOghciGgXueZCtoab4u7mAOyQagku/QRcRmohLcx6eXNS2Jbz1lmzjaobCZ3Tg0gR7ud9b9jXvCSJdrg==",
+      "dependencies": {
+        "@bitgo/bls-dkg": "^1.1.0",
+        "@bitgo/statics": "^8.0.0-rc.12",
+        "@bitgo/utxo-lib": "^3.0.0-rc.4",
+        "@noble/secp256k1": "1.6.0",
+        "@stablelib/hex": "^1.0.0",
+        "bech32": "^2.0.0",
+        "big.js": "^3.1.3",
+        "bigint-crypto-utils": "3.1.4",
+        "bignumber.js": "^9.0.0",
+        "bip32": "^3.0.1",
+        "bitcoinjs-message": "^2.0.0",
+        "bolt11": "^1.4.0",
+        "bs58": "^4.0.1",
+        "create-hmac": "^1.1.7",
+        "debug": "^3.1.0",
+        "ecpair": "^2.0.1",
+        "ethereumjs-util": "7.1.5",
+        "fp-ts": "^2.12.2",
+        "io-ts": "^2.2.17",
+        "libsodium-wrappers-sumo": "^0.7.9",
+        "lodash": "^4.17.15",
+        "noble-bls12-381": "0.7.2",
+        "openpgp": "5.1.0",
+        "paillier-bigint": "3.3.0",
+        "secp256k1": "^4.0.2",
+        "strip-hex-prefix": "^1.0.0",
+        "superagent": "^3.8.3",
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/statics": {
+      "version": "8.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-8.0.0-rc.12.tgz",
+      "integrity": "sha512-BTvnEk4gJtCSdPKLF3Y53t1IhHVVAL9exG5i6R8PdkmmCWgbRtUCRCOLwffA4Vjt3Ym8uYj7M2QYfB2JQEtaww=="
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/utxo-lib": {
+      "version": "3.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-3.0.0-rc.4.tgz",
+      "integrity": "sha512-k2IZeDRAL2Un17690i4r5QbS1sIQhRKvm2/JpBUQMqNIUdqK3U1GQNAvZFakuE7MvYww9/W2LCmnLx/R+lij5Q==",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.0.4-rc.0",
+        "@noble/secp256k1": "^1.6.3",
+        "bip32": "^3.0.1",
+        "bitcoin-ops": "^1.3.0",
+        "bitcoinjs-lib": "npm:@bitgo/bitcoinjs-lib@7.0.0-rc.0",
+        "bn.js": "^5.2.1",
+        "bs58check": "^2.1.2",
+        "cashaddress": "^1.1.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ecpair": "^2.0.1",
+        "elliptic": "^6.5.2",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10.22.0 <17",
+        "npm": ">=3.10.10"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@bitgo/utxo-lib/node_modules/@noble/secp256k1": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/bip32": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-3.0.1.tgz",
+      "integrity": "sha512-Uhpp9aEx3iyiO7CpbNGFxv9WcMIVdGoHG04doQ5Ln0u60uwDah7jUSc3QMV/fSZGm/Oo01/OeAmYevXV+Gz5jQ==",
+      "dependencies": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/bitcoinjs-lib": {
+      "name": "@bitgo/bitcoinjs-lib",
+      "version": "7.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@bitgo/bitcoinjs-lib/-/bitcoinjs-lib-7.0.0-rc.0.tgz",
+      "integrity": "sha512-N45xlHkmoEX87G0QZrezxPOrd8ya+s2INCqJpb2pdZeF/HJ3XezEw5Y1ACNiIpcLJFd/5X5waH9PsD5VSf9HYw==",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "bip174": "^2.0.1",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.1.0",
+        "fastpriorityqueue": "^0.7.1",
+        "ripemd160": "^2.0.2",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node_modules/@bitgo/sdk-coin-ethw/node_modules/secp256k1": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
@@ -37858,6 +38097,219 @@
         "superagent": "^3.8.3"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+        },
+        "secp256k1": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@bitgo/sdk-coin-ethw": {
+      "version": "1.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-ethw/-/sdk-coin-ethw-1.1.0-rc.7.tgz",
+      "integrity": "sha512-p5Ilv03Vn7xmDZbPWZ3nL4WLp9PLVKo2tpLDQXRqK0gRGefRkIZVCgkw8863A0T4W1YdVQuKe7sJSn5xT9rdpw==",
+      "requires": {
+        "@bitgo/abstract-eth": "^1.0.3-rc.19",
+        "@bitgo/sdk-coin-eth": "^2.0.0-rc.15",
+        "@bitgo/sdk-core": "^2.0.0-rc.15",
+        "@bitgo/statics": "^8.0.0-rc.12",
+        "bignumber.js": "^9.0.0",
+        "superagent": "^3.8.3"
+      },
+      "dependencies": {
+        "@bitgo/abstract-eth": {
+          "version": "1.0.3-rc.19",
+          "resolved": "https://registry.npmjs.org/@bitgo/abstract-eth/-/abstract-eth-1.0.3-rc.19.tgz",
+          "integrity": "sha512-pHvEV35yC0HU2EGKqNXayIOmAOvJqjcO1YHgJef4xaHWLjkJeZzMMh5CLXqx/QeRrAHMtfIQGYHQXchEDzda1g==",
+          "requires": {
+            "@bitgo/sdk-coin-eth": "^2.0.0-rc.15",
+            "@bitgo/sdk-core": "^2.0.0-rc.15",
+            "@bitgo/statics": "^8.0.0-rc.12",
+            "@bitgo/utxo-lib": "^3.0.0-rc.4",
+            "bignumber.js": "^8.0.1"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+              "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+            }
+          }
+        },
+        "@bitgo/blake2b": {
+          "version": "3.0.4-rc.0",
+          "resolved": "https://registry.npmjs.org/@bitgo/blake2b/-/blake2b-3.0.4-rc.0.tgz",
+          "integrity": "sha512-/NVV3MY6szDM6gehfRRVZPQ9EmNVNVdnsWhibx+lgFq27z3UiU0ZCxItH03PGFFXSICRiH9xYb0SCOFm+Qn/uQ==",
+          "requires": {
+            "@bitgo/blake2b-wasm": "^3.0.4-rc.0",
+            "nanoassert": "^2.0.0"
+          }
+        },
+        "@bitgo/blake2b-wasm": {
+          "version": "3.0.4-rc.0",
+          "resolved": "https://registry.npmjs.org/@bitgo/blake2b-wasm/-/blake2b-wasm-3.0.4-rc.0.tgz",
+          "integrity": "sha512-HbwX9YpLjUDIDgA1Dp6KgNhrkF06Rplio/3QjVbOdrGcTRfWxKly38l0eHqMnlgIigPjG/UOpCCVBLMzkOkUbA==",
+          "requires": {
+            "nanoassert": "^1.0.0"
+          },
+          "dependencies": {
+            "nanoassert": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+              "integrity": "sha512-C40jQ3NzfkP53NsO8kEOFd79p4b9kDXQMwgiY1z8ZwrDZgUyom0AHwGegF4Dm99L+YoYhuaB0ceerUcXmqr1rQ=="
+            }
+          }
+        },
+        "@bitgo/sdk-coin-eth": {
+          "version": "2.0.0-rc.15",
+          "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-eth/-/sdk-coin-eth-2.0.0-rc.15.tgz",
+          "integrity": "sha512-Ey1ZpnFw00183076/C0zFyDeAj+eke/LgcojC2Oozv58GHTsb3Hd9gqM3MLIcTQpJsSqDSEp+3gj4eI/S96iAg==",
+          "requires": {
+            "@bitgo/sdk-core": "^2.0.0-rc.15",
+            "@bitgo/statics": "^8.0.0-rc.12",
+            "@bitgo/utxo-lib": "^3.0.0-rc.4",
+            "@ethereumjs/common": "^2.4.0",
+            "@ethereumjs/tx": "^3.3.0",
+            "bignumber.js": "^9.0.0",
+            "bn.js": "^5.2.1",
+            "debug": "^3.1.0",
+            "ethereumjs-abi": "^0.6.5",
+            "ethereumjs-util": "7.1.5",
+            "ethers": "^5.1.3",
+            "keccak": "^3.0.2",
+            "lodash": "^4.17.14",
+            "secp256k1": "4.0.2",
+            "superagent": "^3.8.3"
+          }
+        },
+        "@bitgo/sdk-core": {
+          "version": "2.0.0-rc.15",
+          "resolved": "https://registry.npmjs.org/@bitgo/sdk-core/-/sdk-core-2.0.0-rc.15.tgz",
+          "integrity": "sha512-x9TBgoSOghciGgXueZCtoab4u7mAOyQagku/QRcRmohLcx6eXNS2Jbz1lmzjaobCZ3Tg0gR7ud9b9jXvCSJdrg==",
+          "requires": {
+            "@bitgo/bls-dkg": "^1.1.0",
+            "@bitgo/statics": "^8.0.0-rc.12",
+            "@bitgo/utxo-lib": "^3.0.0-rc.4",
+            "@noble/secp256k1": "1.6.0",
+            "@stablelib/hex": "^1.0.0",
+            "bech32": "^2.0.0",
+            "big.js": "^3.1.3",
+            "bigint-crypto-utils": "3.1.4",
+            "bignumber.js": "^9.0.0",
+            "bip32": "^3.0.1",
+            "bitcoinjs-message": "^2.0.0",
+            "bolt11": "^1.4.0",
+            "bs58": "^4.0.1",
+            "create-hmac": "^1.1.7",
+            "debug": "^3.1.0",
+            "ecpair": "^2.0.1",
+            "ethereumjs-util": "7.1.5",
+            "fp-ts": "^2.12.2",
+            "io-ts": "^2.2.17",
+            "libsodium-wrappers-sumo": "^0.7.9",
+            "lodash": "^4.17.15",
+            "noble-bls12-381": "0.7.2",
+            "openpgp": "5.1.0",
+            "paillier-bigint": "3.3.0",
+            "secp256k1": "^4.0.2",
+            "strip-hex-prefix": "^1.0.0",
+            "superagent": "^3.8.3",
+            "tweetnacl": "^1.0.3"
+          }
+        },
+        "@bitgo/statics": {
+          "version": "8.0.0-rc.12",
+          "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-8.0.0-rc.12.tgz",
+          "integrity": "sha512-BTvnEk4gJtCSdPKLF3Y53t1IhHVVAL9exG5i6R8PdkmmCWgbRtUCRCOLwffA4Vjt3Ym8uYj7M2QYfB2JQEtaww=="
+        },
+        "@bitgo/utxo-lib": {
+          "version": "3.0.0-rc.4",
+          "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-3.0.0-rc.4.tgz",
+          "integrity": "sha512-k2IZeDRAL2Un17690i4r5QbS1sIQhRKvm2/JpBUQMqNIUdqK3U1GQNAvZFakuE7MvYww9/W2LCmnLx/R+lij5Q==",
+          "requires": {
+            "@bitgo/blake2b": "^3.0.4-rc.0",
+            "@noble/secp256k1": "^1.6.3",
+            "bip32": "^3.0.1",
+            "bitcoin-ops": "^1.3.0",
+            "bitcoinjs-lib": "npm:@bitgo/bitcoinjs-lib@7.0.0-rc.0",
+            "bn.js": "^5.2.1",
+            "bs58check": "^2.1.2",
+            "cashaddress": "^1.1.0",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "ecpair": "^2.0.1",
+            "elliptic": "^6.5.2",
+            "typeforce": "^1.11.3",
+            "varuint-bitcoin": "^1.1.2"
+          },
+          "dependencies": {
+            "@noble/secp256k1": {
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+              "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
+            }
+          }
+        },
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        },
+        "bip32": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/bip32/-/bip32-3.0.1.tgz",
+          "integrity": "sha512-Uhpp9aEx3iyiO7CpbNGFxv9WcMIVdGoHG04doQ5Ln0u60uwDah7jUSc3QMV/fSZGm/Oo01/OeAmYevXV+Gz5jQ==",
+          "requires": {
+            "@types/node": "10.12.18",
+            "bs58check": "^2.1.1",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "typeforce": "^1.11.5",
+            "wif": "^2.0.6"
+          }
+        },
+        "bitcoinjs-lib": {
+          "version": "npm:@bitgo/bitcoinjs-lib@7.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@bitgo/bitcoinjs-lib/-/bitcoinjs-lib-7.0.0-rc.0.tgz",
+          "integrity": "sha512-N45xlHkmoEX87G0QZrezxPOrd8ya+s2INCqJpb2pdZeF/HJ3XezEw5Y1ACNiIpcLJFd/5X5waH9PsD5VSf9HYw==",
+          "requires": {
+            "bech32": "^2.0.0",
+            "bip174": "^2.0.1",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.1.0",
+            "fastpriorityqueue": "^0.7.1",
+            "ripemd160": "^2.0.2",
+            "typeforce": "^1.11.3",
+            "varuint-bitcoin": "^1.1.2",
+            "wif": "^2.0.1"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
         "debug": {
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@bitgo/sdk-coin-dash": "^1.1.1",
     "@bitgo/sdk-coin-eos": "^1.0.2",
     "@bitgo/sdk-coin-eth": "^1.1.1",
+    "@bitgo/sdk-coin-ethw": "^1.1.0-rc.3",
     "@bitgo/sdk-coin-ltc": "^1.1.1",
     "@bitgo/sdk-coin-trx": "^1.0.2",
     "@bitgo/sdk-coin-xlm": "^1.0.2",

--- a/src/components/CoinsSelectAutocomplete/CoinsSelectAutocomplete.tsx
+++ b/src/components/CoinsSelectAutocomplete/CoinsSelectAutocomplete.tsx
@@ -60,6 +60,12 @@ const prod = [
     value: 'eth',
   },
   {
+    Title: 'ETHw',
+    Description: 'Ethereum PoW',
+    Icon: 'eth',
+    value: 'ethw',
+  },
+  {
     Title: 'ERC',
     Description: 'ERC20 Token',
     Icon: 'eth',

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { CoinsSelectAutocomplete } from '~/components';
 import { useAlertBanner } from '~/contexts';
-import { assert, isRecoveryTransaction, safeEnv, toWei } from '~/helpers';
+import { assert, isRecoveryTransaction, safeEnv, toWei, getEthLikeRecoveryChainId } from '~/helpers';
 import { useLocalStorageState } from '~/hooks';
 import { AvalancheCForm } from './AvalancheCForm';
 import { BitcoinCashForm } from './BitcoinCashForm';
@@ -199,6 +199,7 @@ function Form() {
       );
     case 'eth':
     case 'gteth':
+    case 'ethw':
       return (
         <EthereumForm
           key={coin}
@@ -224,7 +225,7 @@ function Form() {
                     maxPriorityFeePerGas: toWei(maxPriorityFeePerGas),
                   },
                   replayProtectionOptions: {
-                    chain: bitGoEnvironment === 'prod' ? 1 : 5,
+                    chain: getEthLikeRecoveryChainId(coin, bitGoEnvironment),
                     hardfork: 'london',
                   },
                   bitgoKey: '',

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { CoinsSelectAutocomplete } from '~/components';
 import { useAlertBanner } from '~/contexts';
-import { assert, isRecoveryTransaction, safeEnv, toWei } from '~/helpers';
+import { assert, getEthLikeRecoveryChainId, isRecoveryTransaction, safeEnv, toWei } from '~/helpers';
 import { AvalancheCForm } from './AvalancheCForm';
 import { BitcoinCashForm } from './BitcoinCashForm';
 import { BitcoinForm } from './BitcoinForm';
@@ -79,6 +79,7 @@ function Form() {
       );
     case 'eth':
     case 'gteth':
+    case 'ethw':
       return (
         <EthereumForm
           key={coin}
@@ -104,7 +105,7 @@ function Form() {
                     maxPriorityFeePerGas: toWei(maxPriorityFeePerGas),
                   },
                   replayProtectionOptions: {
-                    chain: bitGoEnvironment === 'prod' ? 1 : 5,
+                    chain: getEthLikeRecoveryChainId(coin, bitGoEnvironment),
                     hardfork: 'london',
                   },
                   bitgoKey: '',

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,6 +9,10 @@ export function toWei(gas: number) {
   return gas * GWEI;
 }
 
+export function getEthLikeRecoveryChainId(coinName: string, bitGoEnvironment: string) {
+  return coinName === 'ethw' ? 10001 : bitGoEnvironment === 'prod' ? 1 : 5
+}
+
 export function safeEnv(value: string | undefined): 'prod' | 'test' {
   if (value !== 'test' && value !== 'prod') {
     throw new Error(


### PR DESCRIPTION
Add support to ETHw to unsigned-sweep and non-bitgo. ETHw is to support an eventual PoW fork of ETH after the merge. Trying to recover it will fail for now since ETHw chain id is not confirmed neither there is a block explorer url.

BG-55419