### PR TITLE
feat: Create Broadcastable Txs from Signed MPC Tx

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -309,6 +309,23 @@ async function createWindow() {
     const sdkJson = sdk.toJSON();
     return Promise.resolve(sdkJson.user || sdkJson.token);
   });
+
+  ipcMain.handle('createBroadcastableSweepTransaction', async (event, coin, parameters) => {
+    switch (coin) {
+      // Temporary measure till this is refactored into Basecoin
+      case 'ada':
+      case 'tada':
+      case 'dot':
+      case 'tdot':
+      case 'sol':
+      case 'tsol': {
+        const coinInstance = sdk.coin(coin) as Ada | Tada | Dot | Tdot | Sol | Tsol;
+        return coinInstance.createBroadcastableSweepTransaction(parameters);
+      }
+      default:
+        return new Error(`Coin: ${coin} does not support creating a broadcastable creation`);
+    }
+  });
 }
 
 void app.whenReady().then(createWindow);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -15,10 +15,21 @@ import type { ConsolidationRecoveryOptions, ConsolidationRecoveryBatch } from '@
 import type { Chain, Hardfork } from '@ethereumjs/common';
 import { contextBridge, ipcRenderer } from 'electron';
 import type { ObjectEncodingOptions } from 'node:fs';
+import {
+  BroadcastableSweepTransaction,
+  createAdaBroadcastableSweepTransactionParameters,
+  createDotBroadcastableSweepTransactionParameters, createSolBroadcastableSweepTransactionParameters,
+} from '../types';
 
 type User = { username: string };
 
 type Commands = {
+  createBroadcastableSweepTransaction(
+    coin: string,
+    parameters: createAdaBroadcastableSweepTransactionParameters |
+      createDotBroadcastableSweepTransactionParameters |
+      createSolBroadcastableSweepTransactionParameters
+  ): Promise<Error | BroadcastableSweepTransaction>
   recoverConsolidations(
     coin: string,
     params: ConsolidationRecoveryOptions
@@ -109,6 +120,9 @@ const queries: Queries = {
 };
 
 const commands: Commands = {
+  createBroadcastableSweepTransaction(coin, parameters): Promise<Error | BroadcastableSweepTransaction> {
+    return ipcRenderer.invoke('createBroadcastableSweepTransaction', coin, parameters);
+  },
   recoverConsolidations(coin: string, params: ConsolidationRecoveryOptions): Promise<Error | ConsolidationRecoveryBatch> {
     return ipcRenderer.invoke('recoverConsolidations', coin, params);
   },

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -1,0 +1,13 @@
+import { Ada, Tada } from '@bitgo-beta/sdk-coin-ada';
+import { Dot, Tdot } from '@bitgo-beta/sdk-coin-dot';
+import { Sol, Tsol } from '@bitgo-beta/sdk-coin-sol';
+
+export type createAdaBroadcastableSweepTransactionParameters = Parameters<Ada['createBroadcastableSweepTransaction']>[0] | Parameters<Tada['createBroadcastableSweepTransaction']>[0];
+export type createDotBroadcastableSweepTransactionParameters = Parameters<Dot['createBroadcastableSweepTransaction']>[0] | Parameters<Tdot['createBroadcastableSweepTransaction']>[0];
+export type createSolBroadcastableSweepTransactionParameters = Parameters<Sol['createBroadcastableSweepTransaction']>[0] | Parameters<Tsol['createBroadcastableSweepTransaction']>[0];
+
+export type BroadcastableSweepTransaction = Awaited<ReturnType<
+  Ada['createBroadcastableSweepTransaction'] | Tada['createBroadcastableSweepTransaction'] |
+  Dot['createBroadcastableSweepTransaction'] | Tdot['createBroadcastableSweepTransaction'] |
+  Sol ['createBroadcastableSweepTransaction'] | Tsol['createBroadcastableSweepTransaction']
+>>;

--- a/src/components/Filefield/Filefield.tsx
+++ b/src/components/Filefield/Filefield.tsx
@@ -1,0 +1,58 @@
+import clsx from 'clsx';
+
+export type FilefieldProps = {
+  Disabled?: boolean;
+  Width: 'fill' | 'hug';
+  Label: string;
+  Invalid?: boolean;
+  HelperText?: string;
+} & JSX.IntrinsicElements['input'];
+
+export function Filefield({
+  Disabled,
+  Width,
+  HelperText,
+  Invalid,
+  type = 'file',
+  Label,
+  ...hostProps
+}: FilefieldProps) {
+  return (
+    <div
+      className={clsx('tw-flex-col', {
+        'tw-opacity-50': Disabled,
+        'tw-flex': Width === 'fill',
+        'tw-inline-flex': Width === 'hug',
+      })}
+    >
+      <label
+        className={clsx('tw-text-label-1 tw-font-semibold tw-mb-1', {
+          'tw-text-slate-900': !Invalid,
+          'tw-text-red-500': Invalid,
+        })}
+        htmlFor={hostProps.id}
+      >
+        {Label}
+        <input
+          {...hostProps}
+          type={type}
+          className={clsx(
+            'tw-appearance-none tw-flex tw-w-full tw-py-2 tw-px-4 tw-bg-transparent tw-box-border tw-border tw-border-solid tw-border-gray-700 tw-bg-white tw-text-body tw-text-slate-900 tw-font-normal tw-items-center tw-justify-center tw-rounded tw-relative',
+            'placeholder:tw-text-gray-700',
+            'focus:tw-outline-none',
+            {
+              'focus:tw-border-blue-500': !Invalid,
+              'tw-border-red-500': Invalid,
+            }
+          )}
+          style={undefined}
+        />
+        {HelperText && (
+          <div className="tw-mt-1 tw-text-gray-700 tw-text-label-2">
+            {HelperText}
+          </div>
+        )}
+      </label>
+    </div>
+  );
+}

--- a/src/components/Filefield/index.ts
+++ b/src/components/Filefield/index.ts
@@ -1,0 +1,1 @@
+export * from './Filefield';

--- a/src/components/FormikFilefield/FormikFilefield.tsx
+++ b/src/components/FormikFilefield/FormikFilefield.tsx
@@ -1,0 +1,19 @@
+import { FieldConfig } from 'formik';
+import { Filefield, FilefieldProps } from '../Filefield';
+
+type FormikFilefieldProps = FieldConfig<File>;
+
+export function FormikFilefield({
+  HelperText,
+  ...props
+}: FormikFilefieldProps &
+  Omit<FilefieldProps, 'Invalid' | 'type'> &
+  Omit<JSX.IntrinsicElements['input'], 'value'>) {
+  return (
+    <Filefield
+      {...props}
+      type='file'
+      HelperText={HelperText}
+    />
+  );
+}

--- a/src/components/FormikFilefield/index.ts
+++ b/src/components/FormikFilefield/index.ts
@@ -1,0 +1,1 @@
+export * from './FormikFilefield';

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -12,6 +12,7 @@ import { EvmCrossChainRecoveryCoin } from './EvmCrossChainRecoveryCoin';
 import { EvmCrossChainRecoveryWallet } from './EvmCrossChainRecoveryWallet/EvmCrossChainRecoveryWallet';
 import { BuildUnsignedConsolidationIndex } from './BuildUnsignedConsolidation';
 import { BuildUnsignedConsolidationCoin } from '~/containers/BuildUnsignedConsolidation/BuildUnsignedConsolidationCoin';
+import { CreateBroadcastableTransactionIndex } from '~/containers/CreateBroadcastableTransaction';
 
 export default function App() {
   return (
@@ -51,6 +52,13 @@ export default function App() {
       >
         <Route index element={<BuildUnsignedConsolidationIndex />} />
         <Route path=":coin" element={<BuildUnsignedConsolidationCoin />} />
+        <Route path=":coin/success" element={<SuccessfulRecovery />} />
+      </Route>
+      <Route
+        path="/:env/create-broadcastable-transaction/*"
+        element={<UnauthenticatedPageLayout Title="Create Broadcastable Transaction" Description="This tool will construct a broadcastable transaction given a signed transaction from OVC" />}
+      >
+        <Route index element={<CreateBroadcastableTransactionIndex />} />
         <Route path=":coin/success" element={<SuccessfulRecovery />} />
       </Route>
       <Route

--- a/src/containers/CreateBroadcastableTransaction/CreateBroadcastableTransactionIndex.tsx
+++ b/src/containers/CreateBroadcastableTransaction/CreateBroadcastableTransactionIndex.tsx
@@ -1,0 +1,155 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { FormikFilefield } from '~/components/FormikFilefield';
+import { Form, FormikProvider, useFormik } from 'formik';
+import * as Yup from 'yup';
+import { Button } from '~/components';
+import type {
+  BroadcastableSweepTransaction,
+  createAdaBroadcastableSweepTransactionParameters,
+  createDotBroadcastableSweepTransactionParameters,
+  createSolBroadcastableSweepTransactionParameters,
+} from '~/utils/types';
+import { assert, safeEnv } from '~/helpers';
+import { useAlertBanner } from '~/contexts';
+
+function isBroadcastableTransaction(
+  json: unknown
+): json is BroadcastableSweepTransaction {
+  const broadcastableTransaction = json as BroadcastableSweepTransaction;
+  return (
+    broadcastableTransaction &&
+    broadcastableTransaction.length !== undefined &&
+    broadcastableTransaction.length > 0 &&
+    broadcastableTransaction[0].serializedTx !== undefined
+  );
+}
+
+function isSignedTransaction(
+  json: unknown
+): json is
+  | createAdaBroadcastableSweepTransactionParameters
+  | createDotBroadcastableSweepTransactionParameters
+  | createSolBroadcastableSweepTransactionParameters {
+  const signedTransaction = json as
+    | createAdaBroadcastableSweepTransactionParameters
+    | createDotBroadcastableSweepTransactionParameters
+    | createSolBroadcastableSweepTransactionParameters;
+  return (
+    signedTransaction &&
+    signedTransaction.signatureShares !== undefined &&
+    signedTransaction.signatureShares.length > 0
+  );
+}
+
+export function CreateBroadcastableTransactionIndex() {
+  const { env } = useParams<{ env: string }>();
+  const [, setAlert] = useAlertBanner();
+
+  const environment = safeEnv(env);
+  const navigate = useNavigate();
+  const formik = useFormik<{ tx?: File }>({
+    initialValues: {
+      tx: undefined,
+    },
+    onSubmit: async (values, formikHelpers) => {
+      if (values.tx) {
+        formikHelpers.setSubmitting(true);
+        await window.commands.setBitGoEnvironment(environment);
+        const fileReader = new FileReader();
+        fileReader.readAsText(values.tx, 'UTF-8');
+        fileReader.onload = async event => {
+          try {
+            const tx = JSON.parse(event.target?.result as string) as
+              | createAdaBroadcastableSweepTransactionParameters
+              | createDotBroadcastableSweepTransactionParameters
+              | createSolBroadcastableSweepTransactionParameters;
+
+            assert(isSignedTransaction(tx), 'Signed transaction not found');
+
+            const coin = tx.signatureShares[0].txRequest.walletCoin;
+            const chainData = await window.queries.getChain(coin);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const broadcastTx: Error | BroadcastableSweepTransaction =
+              await window.commands.createBroadcastableSweepTransaction(
+                coin,
+                tx
+              );
+
+            assert(
+              isBroadcastableTransaction(broadcastTx),
+              'Broadcastable transaction not found'
+            );
+
+            if (broadcastTx instanceof Error) {
+              throw broadcastTx;
+            }
+
+            const showSaveDialogData = await window.commands.showSaveDialog({
+              filters: [
+                {
+                  name: 'Custom File Type',
+                  extensions: ['json'],
+                },
+              ],
+              defaultPath: `~/${chainData}-broadcastable-mpc-tx-${Date.now()}.json`,
+            });
+            if (!showSaveDialogData.filePath) {
+              throw new Error('No file path selected');
+            }
+
+            await window.commands.writeFile(
+              showSaveDialogData.filePath,
+              JSON.stringify(broadcastTx, null, 2),
+              { encoding: 'utf8' }
+            );
+            navigate(
+              `/${environment}/create-broadcastable-transaction/${coin}/success`
+            );
+          } catch (error) {
+            if (error instanceof Error) {
+              formikHelpers.setFieldError('tx', error.message);
+              setAlert(error.message);
+            } else {
+              console.log(error);
+            }
+            formikHelpers.setSubmitting(false);
+          }
+        };
+      } else {
+        formikHelpers.setFieldError('tx', 'File is required');
+      }
+    },
+    validationSchema: Yup.object({
+      tx: Yup.mixed().required('File is required'),
+    }).required(),
+  });
+
+  return (
+    <FormikProvider value={formik}>
+      <Form>
+        <div className="tw-mb-4">
+          <FormikFilefield
+            name="tx"
+            accept=".json"
+            Width="fill"
+            Label="Upload Signed Transaction"
+            onChange={event => {
+              formik
+                .setFieldValue('tx', event.currentTarget.files?.[0])
+                .catch(console.error);
+            }}
+          />
+        </div>
+        <Button
+          Variant="primary"
+          Width="fill"
+          type="submit"
+          Disabled={formik.isSubmitting || !formik.values.tx}
+          disabled={formik.isSubmitting || !formik.values.tx}
+        >
+          Create Transaction
+        </Button>
+      </Form>
+    </FormikProvider>
+  );
+}

--- a/src/containers/CreateBroadcastableTransaction/index.ts
+++ b/src/containers/CreateBroadcastableTransaction/index.ts
@@ -1,0 +1,1 @@
+export * from './CreateBroadcastableTransactionIndex';

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -93,6 +93,12 @@ export function Home() {
                     Description='Build an unsigned transaction to consolidate a wallet without using BitGo.'
                     to={`/${env}/build-unsigned-consolidation`}
                 />
+                <LinkCardItem
+                  Tag={Link}
+                  Title='Create Broadcastable MPC Transaction'
+                  Description='Build a broadcastable MPC transaction without using BitGo.'
+                  to={`/${env}/create-broadcastable-transaction`}
+                />
               </LinkCard>
             </div>
             <div className="md:tw-flex-grow">

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -17,11 +17,22 @@ import  type {
 import type { Chain, Hardfork } from '@ethereumjs/common';
 import { contextBridge, ipcRenderer } from 'electron';
 import type { ObjectEncodingOptions } from 'node:fs';
-import { ConsolidationRecoveryBatch, ConsolidationRecoveryOptions } from '@bitgo/sdk-coin-trx';
+import { ConsolidationRecoveryBatch, ConsolidationRecoveryOptions } from '@bitgo-beta/sdk-coin-trx';
+import {
+  BroadcastableSweepTransaction,
+  createAdaBroadcastableSweepTransactionParameters,
+  createDotBroadcastableSweepTransactionParameters, createSolBroadcastableSweepTransactionParameters,
+} from '~/utils/types';
 
 type User = { username: string };
 
 type Commands = {
+  createBroadcastableSweepTransaction(
+    coin: string,
+    parameters: createAdaBroadcastableSweepTransactionParameters |
+      createDotBroadcastableSweepTransactionParameters |
+      createSolBroadcastableSweepTransactionParameters
+  ): Promise<Error | BroadcastableSweepTransaction>
   recoverConsolidations(
     coin: string,
     params: ConsolidateRecoverOptions,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,13 @@
+import { Ada, Tada } from '@bitgo-beta/sdk-coin-ada';
+import { Dot, Tdot } from '@bitgo-beta/sdk-coin-dot';
+import { Sol, Tsol } from '@bitgo-beta/sdk-coin-sol';
+
+export type createAdaBroadcastableSweepTransactionParameters = Parameters<Ada['createBroadcastableSweepTransaction']>[0] | Parameters<Tada['createBroadcastableSweepTransaction']>[0];
+export type createDotBroadcastableSweepTransactionParameters = Parameters<Dot['createBroadcastableSweepTransaction']>[0] | Parameters<Tdot['createBroadcastableSweepTransaction']>[0];
+export type createSolBroadcastableSweepTransactionParameters = Parameters<Sol['createBroadcastableSweepTransaction']>[0] | Parameters<Tsol['createBroadcastableSweepTransaction']>[0];
+
+export type BroadcastableSweepTransaction = Awaited<ReturnType<
+  Ada['createBroadcastableSweepTransaction'] | Tada['createBroadcastableSweepTransaction'] |
+  Dot['createBroadcastableSweepTransaction'] | Tdot['createBroadcastableSweepTransaction'] |
+  Sol ['createBroadcastableSweepTransaction'] | Tsol['createBroadcastableSweepTransaction']
+>>;


### PR DESCRIPTION
- When MPC recovery transactions are signed in OVC, they are not in a broadcastable state. This pr enables the user to transform their signed tx into a broadcastable tx.

Ticket: WP-470
<img width="912" alt="Screenshot 2023-09-06 at 11 39 07 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/101133667/db4c6c80-d5cc-4753-a560-297fff04e591">
<img width="912" alt="Screenshot 2023-09-06 at 11 39 01 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/101133667/99b98dac-7971-4e51-bea3-83fd8090cf79">
<img width="912" alt="Screenshot 2023-09-06 at 11 38 56 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/101133667/86035273-9626-4fbf-b23e-8b74a5a1d99f">
