### PR TITLE
feat(WRW): change tss coins recovery form format

### DIFF
--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -843,12 +843,17 @@ function Form() {
             try {
               await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
               const chainData = await window.queries.getChain(coin);
+              const { publicKey, secretKey } = values;
+              const durableNonce =
+                publicKey && secretKey ? { publicKey, secretKey } : undefined;
               const recoverData = await window.commands.recover(coin, {
                 bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
                 ignoreAddressTypes: [],
                 userKey: '',
                 backupKey: '',
                 recoveryDestination: values.recoveryDestination,
+                seed: values.seed,
+                durableNonce,
               });
               assert(
                 isRecoveryTransaction(recoverData),
@@ -914,6 +919,7 @@ function Form() {
                 userKey: '',
                 backupKey: '',
                 recoveryDestination: values.recoveryDestination,
+                seed: values.seed,
               });
               assert(
                 isRecoveryTransaction(recoverData),

--- a/src/containers/BuildUnsignedSweepCoin/CardanoForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/CardanoForm.tsx
@@ -13,8 +13,7 @@ import {
 const validationSchema = Yup.object({
   bitgoKey: Yup.string().required(),
   recoveryDestination: Yup.string().required(),
-  scan: Yup.number().required(),
-  startingScanIndex: Yup.number().required(),
+  seed: Yup.string(),
 }).required();
 
 export type CardanoFormProps = {
@@ -32,8 +31,7 @@ export function CardanoForm({ onSubmit }: CardanoFormProps) {
     initialValues: {
       bitgoKey: '',
       recoveryDestination: '',
-      scan: 20,
-      startingScanIndex: 0,
+      seed: undefined,
     },
     validationSchema,
   });
@@ -54,25 +52,17 @@ export function CardanoForm({ onSubmit }: CardanoFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikTextfield
+            HelperText="Your user seed as found on your KeyCard as Key ID. Most wallets will not have this and you can leave it blank."
+            Label="Seed (optional)"
+            name="seed"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="The amount of addresses without transactions to scan before stopping the tool."
-            Label="Address Scanning Factor"
-            name="scan"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="This is the index to start scanning from, typically used to scan more indexes. You can call this recover function again starting from scanIndex + 1."
-            Label="Starting Scan Index"
-            name="startingScanIndex"
             Width="fill"
           />
         </div>

--- a/src/containers/BuildUnsignedSweepCoin/SolanaForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/SolanaForm.tsx
@@ -13,8 +13,7 @@ import {
 const validationSchema = Yup.object({
   bitgoKey: Yup.string().required(),
   recoveryDestination: Yup.string().required(),
-  scan: Yup.number().required(),
-  startingScanIndex: Yup.number().required(),
+  seed: Yup.string(),
 })
   .required()
   .shape(
@@ -50,10 +49,9 @@ export function SolanaForm({ onSubmit }: SolanaFormProps) {
     initialValues: {
       bitgoKey: '',
       recoveryDestination: '',
-      scan: 20,
-      startingScanIndex: 0,
       publicKey: '',
       secretKey: '',
+      seed: undefined,
     },
     validationSchema,
   });
@@ -84,6 +82,14 @@ export function SolanaForm({ onSubmit }: SolanaFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikTextfield
+            HelperText="Your user seed as found on your KeyCard as Key ID. Most wallets will not have this and you can leave it blank."
+            Label="Seed (optional)"
+            name="seed"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
@@ -105,22 +111,6 @@ export function SolanaForm({ onSubmit }: SolanaFormProps) {
             Label="Durable Nonce: Secret Key"
             name="secretKey"
             rows={2}
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="The amount of addresses without transactions to scan before stopping the tool."
-            Label="Address Scanning Factor"
-            name="scan"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="This is the index to start scanning from, typically used to scan more indexes. You can call this recover function again starting from scanIndex + 1."
-            Label="Starting Scan Index"
-            name="startingScanIndex"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/CardanoForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/CardanoForm.tsx
@@ -15,8 +15,6 @@ const validationSchema = Yup.object({
     .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
     .label('Key Recovery Service'),
   recoveryDestination: Yup.string().required(),
-  scan: Yup.number().required(),
-  startingScanIndex: Yup.number().required(),
   userKey: Yup.string().required(),
   walletPassphrase: Yup.string().required(),
 }).required();
@@ -38,8 +36,6 @@ export function CardanoForm({ onSubmit }: CardanoFormProps) {
       bitgoKey: '',
       krsProvider: '',
       recoveryDestination: '',
-      scan: 20,
-      startingScanIndex: 0,
       userKey: '',
       walletPassphrase: '',
     },
@@ -98,22 +94,6 @@ export function CardanoForm({ onSubmit }: CardanoFormProps) {
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="The amount of addresses without transactions to scan before stopping the tool."
-            Label="Address Scanning Factor"
-            name="scan"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="This is the index to start scanning from, typically used to scan more indexes. You can call this recover function again starting from scanIndex + 1."
-            Label="Starting Scan Index"
-            name="startingScanIndex"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -107,9 +107,6 @@ function Form() {
               const chainData = await window.queries.getChain(coin);
               const recoverData = await window.commands.recover(coin, {
                 ...values,
-                scan: Number(values.scan),
-                startingScanIndex: Number(values.startingScanIndex),
-                bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
                 ignoreAddressTypes: ['p2wsh'],
               });
               assert(
@@ -164,8 +161,6 @@ function Form() {
               const chainData = await window.queries.getChain(coin);
               const recoverData = await window.commands.recover(coin, {
                 ...values,
-                scan: Number(values.scan),
-                startingScanIndex: Number(values.startingScanIndex),
                 bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
                 ignoreAddressTypes: [],
               });
@@ -219,14 +214,12 @@ function Form() {
             try {
               await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
               const chainData = await window.queries.getChain(coin);
-              const { publicKey, secretKey, scan, startingScanIndex, ...rest } =
+              const { publicKey, secretKey, ...rest } =
                 values;
               const durableNonce =
                 publicKey && secretKey ? { publicKey, secretKey } : undefined;
               const recoverData = await window.commands.recover(coin, {
                 ...rest,
-                scan: Number(scan),
-                startingScanIndex: Number(startingScanIndex),
                 durableNonce,
                 bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
                 ignoreAddressTypes: [],

--- a/src/containers/NonBitGoRecoveryCoin/PolkadotForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/PolkadotForm.tsx
@@ -15,8 +15,6 @@ const validationSchema = Yup.object({
     .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
     .label('Key Recovery Service'),
   recoveryDestination: Yup.string().required(),
-  scan: Yup.number().required(),
-  startingScanIndex: Yup.number().required(),
   userKey: Yup.string().required(),
   walletPassphrase: Yup.string().required(),
 }).required();
@@ -38,8 +36,6 @@ export function PolkadotForm({ onSubmit }: PolkadotFormProps) {
       bitgoKey: '',
       krsProvider: '',
       recoveryDestination: '',
-      scan: 20,
-      startingScanIndex: 0,
       userKey: '',
       walletPassphrase: '',
     },
@@ -111,22 +107,6 @@ export function PolkadotForm({ onSubmit }: PolkadotFormProps) {
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="The amount of addresses without transactions to scan before stopping the tool."
-            Label="Address Scanning Factor"
-            name="scan"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="This is the index to start scanning from, typically used to scan more indexes. You can call this recover function again starting from scanIndex + 1."
-            Label="Starting Scan Index"
-            name="startingScanIndex"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/SolanaForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/SolanaForm.tsx
@@ -17,8 +17,6 @@ const validationSchema = Yup.object({
     .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
     .label('Key Recovery Service'),
   recoveryDestination: Yup.string().required(),
-  scan: Yup.number().required(),
-  startingScanIndex: Yup.number().required(),
   userKey: Yup.string().required(),
   walletPassphrase: Yup.string().required(),
 })
@@ -59,8 +57,6 @@ export function SolanaForm({ onSubmit }: SolanaFormProps) {
       krsProvider: '',
       publicKey: '',
       recoveryDestination: '',
-      scan: 20,
-      startingScanIndex: 0,
       secretKey: '',
       userKey: '',
       walletPassphrase: '',
@@ -161,22 +157,6 @@ export function SolanaForm({ onSubmit }: SolanaFormProps) {
             Label="Durable Nonce: Secret Key"
             name="secretKey"
             rows={2}
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="The amount of addresses without transactions to scan before stopping the tool."
-            Label="Address Scanning Factor"
-            name="scan"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="This is the index to start scanning from, typically used to scan more indexes. You can call this recover function again starting from scanIndex + 1."
-            Label="Starting Scan Index"
-            name="startingScanIndex"
             Width="fill"
           />
         </div>

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -66,7 +66,8 @@ export function isRecoveryTransaction(
     ('tx' in value && !!value['tx']) ||
     ('transaction' in value && !!value['transaction']) ||
     ('txid' in value && !!value['txid']) ||
-    ('serializedTx' in value && !!value['serializedTx'])
+    ('serializedTx' in value && !!value['serializedTx']) ||
+    ('txRequests' in value && !!value['txRequests'])
   );
 }
 

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -69,6 +69,7 @@ type Commands = {
       };
       tokenAddress?: string;
       startingScanIndex?: number;
+      seed?: string;
     }
   ): Promise<BackupKeyRecoveryTransansaction | FormattedOfflineVaultTxInfo>;
   wrongChainRecover(


### PR DESCRIPTION
This PR changes the tss coins recovery form formats to conform to the new format specified by the recovery methods in the SDK.

Did the following E2E testing for these changes (for all 3 coins - SOL, DOT, ADA):

- Base Address - Non-Bitgo Recovery
- Base Address - Unsigned Sweep
- Base Address - Unsigned Sweep - Same Keys but Different Seed

TICKET: WP-588

**Non-Bitgo Recovery - Solana:**
<img width="931" alt="Screen Shot 2023-09-07 at 2 52 33 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/f89504e8-1f83-40ce-9b81-a66f4861c5da">
<img width="929" alt="Screen Shot 2023-09-07 at 2 52 42 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/76c0b09f-80c1-41f6-a2bf-fad1aef72f29">

**Non-Bitgo Recovery - Cardano:**
<img width="928" alt="Screen Shot 2023-09-07 at 2 53 05 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/2754061c-cb76-4d22-b340-680a430bb308">

**Non-Bitgo Recovery - Polkadot:**
<img width="928" alt="Screen Shot 2023-09-07 at 2 53 15 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/f8a6ac63-965a-497f-a024-83e3bdc88a1c">

**Unsigned Sweep Recovery:**
<img width="927" alt="Screen Shot 2023-09-07 at 5 14 25 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/5ab604d1-e39c-4062-a95e-b5b25874335f">
<img width="929" alt="Screen Shot 2023-09-07 at 5 14 55 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/5fd9e9e6-0025-4787-bf7f-f610787105bc">
<img width="929" alt="Screen Shot 2023-09-07 at 5 15 05 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/107073833/9aadd495-ce8b-4265-9110-327341a86eb7">


