### PR TITLE
feat: add avaxc token support

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -23,7 +23,7 @@ import { Tia, Ttia } from '@bitgo/sdk-coin-tia';
 import { AbstractUtxoCoin } from '@bitgo/abstract-utxo';
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { Ada, Tada } from '@bitgo/sdk-coin-ada';
-import { AvaxC, TavaxC } from '@bitgo/sdk-coin-avaxc';
+import { AvaxC, TavaxC, AvaxCToken } from '@bitgo/sdk-coin-avaxc';
 import { Bch } from '@bitgo/sdk-coin-bch';
 import { Bcha } from '@bitgo/sdk-coin-bcha';
 import { Bsv } from '@bitgo/sdk-coin-bsv';
@@ -134,6 +134,9 @@ sdk.register('tzeta', Tzeta.createInstance);
 sdk.register('coreum', Coreum.createInstance);
 sdk.register('tcoreum', Tcoreum.createInstance);
 Erc20Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
+  sdk.register(name, coinConstructor);
+});
+AvaxCToken.createTokenConstructors().forEach(({ name, coinConstructor }) => {
   sdk.register(name, coinConstructor);
 });
 

--- a/src/containers/BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx
@@ -1,0 +1,147 @@
+import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
+import { Link } from 'react-router-dom';
+import * as Yup from 'yup';
+import { Button, FormikTextfield } from '~/components';
+
+const validationSchema = Yup.object({
+  backupKey: Yup.string().required(),
+  backupKeyId: Yup.string(),
+  gasLimit: Yup.number()
+    .typeError('Gas limit must be a number')
+    .integer()
+    .positive('Gas limit must be a positive integer')
+    .required(),
+  gasPrice: Yup.number()
+    .typeError('Gas price must be a number')
+    .integer()
+    .positive('Gas price must be a positive integer')
+    .required(),
+  recoveryDestination: Yup.string().required(),
+  tokenAddress: Yup.string().required(),
+  userKey: Yup.string().required(),
+  userKeyId: Yup.string(),
+  walletContractAddress: Yup.string().required(),
+}).required();
+
+export type AvalancheCTokenFormProps = {
+  onSubmit: (
+    values: AvalancheCTokenFormValues,
+    formikHelpers: FormikHelpers<AvalancheCTokenFormValues>
+  ) => void | Promise<void>;
+};
+
+type AvalancheCTokenFormValues = Yup.Asserts<typeof validationSchema>;
+
+export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
+  const formik = useFormik<AvalancheCTokenFormValues>({
+    onSubmit,
+    initialValues: {
+      backupKey: '',
+      backupKeyId: '',
+      gasLimit: 500000,
+      gasPrice: 30,
+      recoveryDestination: '',
+      tokenAddress: '',
+      userKey: '',
+      userKeyId: '',
+      walletContractAddress: '',
+    },
+    validationSchema,
+  });
+
+  return (
+    <FormikProvider value={formik}>
+      <Form>
+        <h4 className="tw-text-body tw-font-semibold tw-border-b-0.5 tw-border-solid tw-border-gray-700 tw-mb-4">
+          Self-managed cold wallet details
+        </h4>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Your user public key, as found on your recovery KeyCard."
+            Label="User Public Key"
+            name="userKey"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Your user Key ID, as found on your KeyCard. Most wallets will not have this and you can leave it blank."
+            Label="User Key ID (optional)"
+            name="userKeyId"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The backup public key for the wallet, as found on your recovery KeyCard."
+            Label="Backup Public Key"
+            name="backupKey"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Your backup Key ID, as found on your KeyCard. Most wallets will not have this and you can leave it blank."
+            Label="Backup Key ID (optional)"
+            name="backupKeyId"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The AVAXC address of the wallet contract. This is also the wallet's base address."
+            Label="Wallet Contract Address"
+            name="walletContractAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address."
+            Label="Token Contract Address"
+            name="tokenAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The address your recovery transaction will send to."
+            Label="Destination Address"
+            name="recoveryDestination"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Gas limit for the AVAXC transaction. The value should be between 30,000 and 20,000,000. The default is 500,000 unit of gas."
+            Label="Gas Limit"
+            name="gasLimit"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Gas price for the AVAXC transaction. The default is 30 Gwei."
+            Label="Gas Price"
+            name="gasPrice"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
+          <Button Tag={Link} to="/" Variant="secondary" Width="hug">
+            Cancel
+          </Button>
+          <Button
+            Variant="primary"
+            Width="hug"
+            type="submit"
+            Disabled={formik.isSubmitting}
+            disabled={formik.isSubmitting}
+          >
+            {formik.isSubmitting ? 'Recovering...' : 'Recover Funds'}
+          </Button>
+        </div>
+      </Form>
+    </FormikProvider>
+  );
+}

--- a/src/containers/NonBitGoRecoveryCoin/AvalancheCTokenForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/AvalancheCTokenForm.tsx
@@ -1,0 +1,167 @@
+import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
+import { Link } from 'react-router-dom';
+import * as Yup from 'yup';
+import {
+  Button,
+  FormikSelectfield,
+  FormikTextarea,
+  FormikTextfield,
+} from '~/components';
+
+const validationSchema = Yup.object({
+  backupKey: Yup.string().required(),
+  gasLimit: Yup.number()
+    .typeError('Gas limit must be a number')
+    .integer()
+    .positive('Gas limit must be a positive integer')
+    .required(),
+  gasPrice: Yup.number()
+    .typeError('Gas price must be a number')
+    .integer()
+    .positive('Gas price must be a positive integer')
+    .required(),
+  krsProvider: Yup.string()
+    .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
+    .label('Key Recovery Service'),
+  recoveryDestination: Yup.string().required(),
+  tokenAddress: Yup.string().required(),
+  userKey: Yup.string().required(),
+  walletContractAddress: Yup.string().required(),
+  walletPassphrase: Yup.string().required(),
+}).required();
+
+export type AvalancheCTokenFormProps = {
+  onSubmit: (
+    values: AvalancheCTokenFormValues,
+    formikHelpers: FormikHelpers<AvalancheCTokenFormValues>
+  ) => void | Promise<void>;
+};
+
+type AvalancheCTokenFormValues = Yup.Asserts<typeof validationSchema>;
+
+export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
+  const formik = useFormik<AvalancheCTokenFormValues>({
+    onSubmit,
+    initialValues: {
+      userKey: '',
+      backupKey: '',
+      tokenAddress: '',
+      walletContractAddress: '',
+      walletPassphrase: '',
+      recoveryDestination: '',
+      krsProvider: '',
+      gasLimit: 500000,
+      gasPrice: 30,
+    },
+    validationSchema,
+  });
+
+  const backupKeyHelperText =
+    formik.values.krsProvider === ''
+      ? 'Your encrypted backup key, as found on your recovery KeyCard.'
+      : 'The backup public key for the wallet, as found on your recovery KeyCard.';
+
+  return (
+    <FormikProvider value={formik}>
+      <Form>
+        <h4 className="tw-text-body tw-font-semibold tw-border-b-0.5 tw-border-solid tw-border-gray-700 tw-mb-4">
+          Self-managed hot wallet details
+        </h4>
+        <div className="tw-mb-4">
+          <FormikSelectfield
+            HelperText="The Key Recovery Service that you chose to manage your backup key. If you have the encrypted backup key, you may leave this blank."
+            Label="Key Recovery Service"
+            name="krsProvider"
+            Width="fill"
+          >
+            <option value="">None</option>
+            <option value="keyternal">Keyternal</option>
+            <option value="bitgoKRSv2">BitGo KRS</option>
+            <option value="dai">Coincover</option>
+          </FormikSelectfield>
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText="Your encrypted user key, as found on your recovery KeyCard."
+            Label="Box A Value"
+            name="userKey"
+            rows={4}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText={backupKeyHelperText}
+            Label="Box B Value"
+            name="backupKey"
+            rows={4}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The AVAXC address of the wallet contract. This is also the wallet's base address."
+            Label="Wallet Contract Address"
+            name="walletContractAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address."
+            Label="Token Contract Address"
+            name="tokenAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The passphrase of the wallet."
+            Label="Wallet Passphrase"
+            name="walletPassphrase"
+            type="password"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The address your recovery transaction will send to."
+            Label="Destination Address"
+            name="recoveryDestination"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Gas limit for the AVAXC transaction. The value should be between 30,000 and 20,000,000. The default is 500,000 units of gas."
+            Label="Gas limit"
+            name="gasLimit"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="Gas price for the AVAXC transaction. The value should be between 1 Gwei and 2500 Gwei. The default is 30 Gwei."
+            Label="Gas Price"
+            name="gasPrice"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
+          <Button Tag={Link} to="/" Variant="secondary" Width="hug">
+            Cancel
+          </Button>
+          <Button
+            Variant="primary"
+            Width="hug"
+            type="submit"
+            Disabled={formik.isSubmitting}
+            disabled={formik.isSubmitting}
+          >
+            {formik.isSubmitting ? 'Recovering...' : 'Recover Funds'}
+          </Button>
+        </div>
+      </Form>
+    </FormikProvider>
+  );
+}

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -28,6 +28,7 @@ import { PolygonForm } from './PolygonForm';
 import { RippleForm } from './RippleForm';
 import { SolanaForm } from './SolanaForm';
 import { TronForm } from './TronForm';
+import { AvalancheCTokenForm } from './AvalancheCTokenForm';
 
 function Form() {
   const { env, coin } = useParams<'env' | 'coin'>();
@@ -214,8 +215,7 @@ function Form() {
             try {
               await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
               const chainData = await window.queries.getChain(coin);
-              const { publicKey, secretKey, ...rest } =
-                values;
+              const { publicKey, secretKey, ...rest } = values;
               const durableNonce =
                 publicKey && secretKey ? { publicKey, secretKey } : undefined;
               const recoverData = await window.commands.recover(coin, {
@@ -412,13 +412,72 @@ function Form() {
             setAlert(undefined);
             setSubmitting(true);
             try {
-              await window.commands.setBitGoEnvironment(
-                bitGoEnvironment,
-                coin
-              );
+              await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
               const chainData = await window.queries.getChain(coin);
               const recoverData = await window.commands.recover(coin, {
                 ...values,
+                gasPrice: toWei(values.gasPrice),
+                bitgoKey: '',
+                ignoreAddressTypes: [],
+              });
+              assert(
+                isRecoveryTransaction(recoverData),
+                'Fully-signed recovery transaction not detected.'
+              );
+
+              const showSaveDialogData = await window.commands.showSaveDialog({
+                filters: [
+                  {
+                    name: 'Custom File Type',
+                    extensions: ['json'],
+                  },
+                ],
+                defaultPath: `~/${chainData}-recovery-${Date.now()}.json`,
+              });
+
+              if (!showSaveDialogData.filePath) {
+                throw new Error('No file path selected');
+              }
+
+              await window.commands.writeFile(
+                showSaveDialogData.filePath,
+                JSON.stringify(recoverData, null, 2),
+                { encoding: 'utf-8' }
+              );
+
+              navigate(
+                `/${bitGoEnvironment}/non-bitgo-recovery/${coin}/success`
+              );
+            } catch (err) {
+              if (err instanceof Error) {
+                setAlert(err.message);
+              } else {
+                console.error(err);
+              }
+              setSubmitting(false);
+            }
+          }}
+        />
+      );
+    case 'avaxcToken':
+    case 'tavaxcToken':
+      return (
+        <AvalancheCTokenForm
+          key={coin}
+          onSubmit={async (values, { setSubmitting }) => {
+            setAlert(undefined);
+            setSubmitting(true);
+            try {
+              await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
+              const parentCoin = env === 'test' ? 'tavaxc' : 'avaxc';
+              const chainData = await getTokenChain(
+                values.tokenAddress.toLowerCase(),
+                parentCoin
+              );
+              const recoverData = await window.commands.recover(parentCoin, {
+                ...values,
+                //TODO(WP-1221): remove and use tokenAddress instead
+                tokenContractAddress: values.tokenAddress.toLowerCase(),
                 gasPrice: toWei(values.gasPrice),
                 bitgoKey: '',
                 ignoreAddressTypes: [],

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -97,19 +97,25 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'avax',
     value: 'avaxc',
   },
+  avaxcToken: {
+    Title: 'AVAXC TOKEN',
+    Description: 'Avalanche C-Chain Token',
+    Icon: 'avax',
+    value: 'avaxcToken',
+  },
   arbeth: {
     Title: 'ARBETH',
     Description: 'Arbitrum',
     Icon: 'arbeth',
     value: 'arbeth',
-    ApiKeyProvider: 'arbiscan.io'
+    ApiKeyProvider: 'arbiscan.io',
   },
   opeth: {
     Title: 'OPETH',
     Description: 'Optimism',
     Icon: 'opeth',
     value: 'opeth',
-    ApiKeyProvider: 'optimistic.etherscan.io'
+    ApiKeyProvider: 'optimistic.etherscan.io',
   },
   near: {
     Title: 'NEAR',
@@ -269,19 +275,25 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'avax',
     value: 'tavaxc',
   },
+  tavaxcToken: {
+    Title: 'TAVAXC TOKEN',
+    Description: 'Testnet Avalanche C-Chain Token',
+    Icon: 'avax',
+    value: 'tavaxcToken',
+  },
   tarbeth: {
     Title: 'TARBETH',
     Description: 'Arbitrum Sepolia',
     Icon: 'arbeth',
     value: 'tarbeth',
-    ApiKeyProvider: 'arbiscan.io'
+    ApiKeyProvider: 'arbiscan.io',
   },
   topeth: {
     Title: 'TOPETH',
     Description: 'Optimism Sepolia',
     Icon: 'opeth',
     value: 'topeth',
-    ApiKeyProvider: 'optimistic.etherscan.io'
+    ApiKeyProvider: 'optimistic.etherscan.io',
   },
   tnear: {
     Title: 'TNEAR',
@@ -375,20 +387,23 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
   },
 } as const;
 
-export const buildUnsignedConsolidationCoins: Record<BitgoEnv, readonly CoinMetadata[]> = {
+export const buildUnsignedConsolidationCoins: Record<
+  BitgoEnv,
+  readonly CoinMetadata[]
+> = {
   prod: [
     allCoinMetas.trx,
     allCoinMetas.ada,
     allCoinMetas.dot,
     allCoinMetas.sol,
-    ],
+  ],
   test: [
     allCoinMetas.ttrx,
     allCoinMetas.tada,
     allCoinMetas.tdot,
     allCoinMetas.tsol,
-  ]
-}
+  ],
+};
 
 export const buildUnsignedSweepCoins: Record<
   BitgoEnv,
@@ -409,6 +424,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.trx,
     allCoinMetas.eos,
     allCoinMetas.avaxc,
+    allCoinMetas.avaxcToken,
     allCoinMetas.arbeth,
     allCoinMetas.opeth,
     allCoinMetas.polygon,
@@ -427,6 +443,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.ttrx,
     allCoinMetas.teos,
     allCoinMetas.tavaxc,
+    allCoinMetas.tavaxcToken,
     allCoinMetas.tarbeth,
     allCoinMetas.topeth,
     allCoinMetas.tpolygon,
@@ -454,6 +471,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.trx,
       allCoinMetas.eos,
       allCoinMetas.avaxc,
+      allCoinMetas.avaxcToken,
       allCoinMetas.arbeth,
       allCoinMetas.opeth,
       allCoinMetas.near,
@@ -482,6 +500,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.ttrx,
       allCoinMetas.teos,
       allCoinMetas.tavaxc,
+      allCoinMetas.tavaxcToken,
       allCoinMetas.tarbeth,
       allCoinMetas.topeth,
       allCoinMetas.tnear,
@@ -525,13 +544,9 @@ export const evmCrossChainRecoveryCoins: Record<
   BitgoEnv,
   readonly CoinMetadata[]
 > = {
-  prod: [
-    allCoinMetas.polygon,
-  ] as const,
-  test: [
-    allCoinMetas.tpolygon,
-  ] as const
-  };
+  prod: [allCoinMetas.polygon] as const,
+  test: [allCoinMetas.tpolygon] as const,
+};
 
 export type WalletMetadata = {
   Title: string;
@@ -555,13 +570,10 @@ export const allWalletMetas = {
     Description: 'Bitgo managed Custody Wallet',
     value: 'custody',
   },
-}
+};
 
-
-export const evmCrossChainRecoveryWallets:
-WalletMetadata[]
- =  [
+export const evmCrossChainRecoveryWallets: WalletMetadata[] = [
   allWalletMetas.hot,
   allWalletMetas.cold,
-  allWalletMetas.custody
-]
+  allWalletMetas.custody,
+];

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -84,6 +84,8 @@ type Commands = {
         secretKey: string;
       };
       tokenAddress?: string;
+      //TODO(WP-1221): remove and use tokenAddress instead
+      tokenContractAddress?: string;
       startingScanIndex?: number;
       seed?: string;
     }


### PR DESCRIPTION
TICKET: WP-885

tested recoveries, check ticket for details

a item in the list is added for AVAXC token and the inputs include the token contract address (similar to erc20)

<img width="1393" alt="Screenshot 2023-12-22 at 3 03 42 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/81980537/9a537152-7c6d-4e10-99ac-7ce4540d2877">
<img width="1388" alt="Screenshot 2023-12-22 at 3 03 12 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/81980537/38ad8177-df0e-4ee8-92bd-29fe4d6c5d84">
<img width="1401" alt="Screenshot 2023-12-22 at 3 03 02 PM" src="https://github.com/BitGo/wallet-recovery-wizard/assets/81980537/fb75a2a8-dca9-442c-bf5a-856ac131301e">

