### PR TITLE
feat: update native avaxc recovery forms

### DIFF
--- a/src/containers/BuildUnsignedSweepCoin/AvalancheCForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/AvalancheCForm.tsx
@@ -4,7 +4,6 @@ import * as Yup from 'yup';
 import { Button, FormikTextfield } from '~/components';
 
 const validationSchema = Yup.object({
-  apiKey: Yup.string().required(),
   backupKey: Yup.string().required(),
   backupKeyId: Yup.string(),
   gasLimit: Yup.number()
@@ -36,7 +35,6 @@ export function AvalancheCForm({ onSubmit }: AvalancheCFormProps) {
   const formik = useFormik<AvalancheCFormValues>({
     onSubmit,
     initialValues: {
-      apiKey: '',
       backupKey: '',
       backupKeyId: '',
       gasLimit: 500000,
@@ -100,14 +98,6 @@ export function AvalancheCForm({ onSubmit }: AvalancheCFormProps) {
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="An API-Key Token from snowtrace.com required for Avalanche C-Chain Mainnet recoveries."
-            Label="API Key"
-            name="apiKey"
             Width="fill"
           />
         </div>

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -269,8 +269,7 @@ function Form() {
             try {
               await window.commands.setBitGoEnvironment(
                 bitGoEnvironment,
-                coin,
-                values.apiKey
+                coin
               );
               const chainData = await window.queries.getChain(coin);
 

--- a/src/containers/NonBitGoRecoveryCoin/AvalancheCForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/AvalancheCForm.tsx
@@ -9,7 +9,6 @@ import {
 } from '~/components';
 
 const validationSchema = Yup.object({
-  apiKey: Yup.string().required(),
   backupKey: Yup.string().required(),
   gasLimit: Yup.number()
     .typeError('Gas limit must be a number')
@@ -43,7 +42,6 @@ export function AvalancheCForm({ onSubmit }: AvalancheCFormProps) {
   const formik = useFormik<AvalancheCFormValues>({
     onSubmit,
     initialValues: {
-      apiKey: '',
       backupKey: '',
       gasLimit: 500000,
       gasPrice: 30,
@@ -120,14 +118,6 @@ export function AvalancheCForm({ onSubmit }: AvalancheCFormProps) {
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
-            Width="fill"
-          />
-        </div>
-        <div className="tw-mb-4">
-          <FormikTextfield
-            HelperText="An API-Key Token from snowtrace.com required for Avalanche C-Chain Mainnet recoveries."
-            Label="API Key"
-            name="apiKey"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -409,8 +409,7 @@ function Form() {
             try {
               await window.commands.setBitGoEnvironment(
                 bitGoEnvironment,
-                coin,
-                values.apiKey
+                coin
               );
               const chainData = await window.queries.getChain(coin);
               const recoverData = await window.commands.recover(coin, {


### PR DESCRIPTION
Since the external fullnode previously used, Snowtrace, was deprecated and replaced by the avax network, the recovery forms must be updated. The only difference is that there is no longer an API key, and updates in WRW must be made based on this. Changes have been tested e2e.

TICKET: WP-1135