### PR TITLE
feat: new workflow to detect PR edit and trigger renovate scan

### DIFF
--- a/.github/workflows/pull-request-edit.yaml
+++ b/.github/workflows/pull-request-edit.yaml
@@ -1,0 +1,31 @@
+name: on_pr_edit
+run-name: 'on_pr_edit: ${{ github.ref_name }}'
+
+on:
+  pull_request:
+    types:
+      - edited
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  run-scan:
+    name: Trigger Renovate Scan
+    if:
+      ${{ contains(github.event.pull_request.body, '[x] <!-- rebase-check -->')
+      && github.event.pull_request.user.login == 'bitgo-renovate-bot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: trigger-renovate-scan
+        uses: BitGo/gha-renovate-bot@master
+        with:
+          target-base-branch: master
+          target-repository: ${{ github.repository }}
+          caller-pr: ${{ github.event.pull_request.number }}
+          trigger-token: ${{ secrets.BITGOBOT_RENOVATE_ACTIONS_GITHUB_TOKEN }} # Should be a PAT


### PR DESCRIPTION
This commit,
1. ensures PR body edit contains Rebase Tick Box is ticked
2. validates PR author is renovate bot or not
3. trigger renovate scan using composite action from BitGo/gha-renovate-bot

Ticket: DO-4550

[Runbook](https://bitgoinc.atlassian.net/wiki/spaces/DEVOPS/pages/2966552581/Runbook+to+work+with+Renovate+created+PRs) has been updated with needed FAQ to be used when [renovate PRs have conflict](https://bitgoinc.atlassian.net/wiki/spaces/DEVOPS/pages/2959114241/FAQ+while+working+with+Renovate#What-do-we-do-when-renovate-PRs-have-conflicts%3F-just-wait-for-it-to-update%3F)

Please help in merging this PR, once approved.