### PR TITLE
chore(deps): bump mimtaching utxo lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@bitgo/sdk-coin-xrp": "1.7.21",
         "@bitgo/sdk-coin-zec": "1.5.21",
         "@bitgo/sdk-coin-zeta": "1.19.0",
-        "@bitgo/utxo-lib": "9.23.0",
+        "@bitgo/utxo-lib": "9.26.0",
         "@ethereumjs/common": "2.6.5",
         "@lottiefiles/react-lottie-player": "3.4.9",
         "clsx": "1.2.1",
@@ -2235,56 +2235,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/abstract-cosmos/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/abstract-cosmos/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/abstract-eth": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@bitgo/abstract-eth/-/abstract-eth-9.0.0.tgz",
@@ -2309,56 +2259,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/abstract-eth/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/abstract-eth/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/abstract-eth/node_modules/debug": {
@@ -2412,56 +2312,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/abstract-utxo/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/abstract-utxo/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/abstract-utxo/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -2503,35 +2353,6 @@
         "superagent": "^7.1.1"
       }
     },
-    "node_modules/@bitgo/blockapis/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
     "node_modules/@bitgo/blockapis/node_modules/@types/superagent": {
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.16.tgz",
@@ -2539,27 +2360,6 @@
       "dependencies": {
         "@types/cookiejar": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@bitgo/blockapis/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/blockapis/node_modules/formidable": {
@@ -2667,56 +2467,6 @@
         "superagent": "3.8.3"
       }
     },
-    "node_modules/@bitgo/sdk-api/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-api/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-api/node_modules/debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -2766,56 +2516,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-arbeth/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-arbeth/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-atom": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-atom/-/sdk-coin-atom-3.16.0.tgz",
@@ -2839,35 +2539,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-atom/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-atom/node_modules/@cosmjs/crypto": {
       "version": "0.29.5",
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
@@ -2880,27 +2551,6 @@
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
         "libsodium-wrappers": "^0.7.6"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-atom/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-avaxc": {
@@ -2924,56 +2574,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-avaxc/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-avaxc/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-avaxc/node_modules/node-addon-api": {
@@ -3060,56 +2660,6 @@
       "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-39.0.0.tgz",
       "integrity": "sha512-Ch0fTQs9JsmFPZcmWPGSC9v1vU9IC0uWag9ouWSyOqd9pZDyb45dM30fuQHEz1pwdRYoxF2IaROHPLMDFLuQRg=="
     },
-    "node_modules/@bitgo/sdk-coin-avaxp/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-avaxp/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-avaxp/node_modules/bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -3177,56 +2727,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-bch/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-bch/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-bcha": {
       "version": "1.7.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-bcha/-/sdk-coin-bcha-1.7.21.tgz",
@@ -3239,56 +2739,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-bcha/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-bcha/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-bld": {
@@ -3323,56 +2773,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-bsv/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-bsv/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-btc": {
       "version": "1.7.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-btc/-/sdk-coin-btc-1.7.21.tgz",
@@ -3387,56 +2787,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-btc/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-btc/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-btg": {
       "version": "1.5.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-btg/-/sdk-coin-btg-1.5.21.tgz",
@@ -3448,56 +2798,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-btg/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-btg/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-coreum": {
@@ -3531,56 +2831,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-dash/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-dash/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-doge": {
       "version": "1.12.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-doge/-/sdk-coin-doge-1.12.21.tgz",
@@ -3592,56 +2842,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-doge/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-doge/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-dot": {
@@ -3696,56 +2896,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-eos/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-eos/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-eth": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-eth/-/sdk-coin-eth-12.0.0.tgz",
@@ -3766,56 +2916,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-eth/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-eth/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-eth/node_modules/node-addon-api": {
@@ -3901,56 +3001,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-ltc/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-ltc/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-near": {
       "version": "1.6.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-near/-/sdk-coin-near-1.6.21.tgz",
@@ -3996,56 +3046,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-opeth/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-opeth/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-osmo": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-osmo/-/sdk-coin-osmo-1.16.0.tgz",
@@ -4079,56 +3079,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-polygon/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-polygon/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-sei": {
@@ -4311,56 +3261,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-trx/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-trx/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-trx/node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -4397,56 +3297,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-xlm/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-xlm/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-xrp": {
       "version": "1.7.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-xrp/-/sdk-coin-xrp-1.7.21.tgz",
@@ -4465,56 +3315,6 @@
         "node": ">=16 <21"
       }
     },
-    "node_modules/@bitgo/sdk-coin-xrp/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-xrp/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@bitgo/sdk-coin-zec": {
       "version": "1.5.21",
       "resolved": "https://registry.npmjs.org/@bitgo/sdk-coin-zec/-/sdk-coin-zec-1.5.21.tgz",
@@ -4526,56 +3326,6 @@
       },
       "engines": {
         "node": ">=16 <21"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-zec/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-coin-zec/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-coin-zeta": {
@@ -4634,56 +3384,6 @@
         "superagent": "^3.8.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@bitgo/sdk-core/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/sdk-core/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/sdk-core/node_modules/bs58": {
@@ -4775,7 +3475,7 @@
         "varuint-bitcoin": "^1.0.4"
       }
     },
-    "node_modules/@bitgo/unspents/node_modules/@bitgo/utxo-lib": {
+    "node_modules/@bitgo/utxo-lib": {
       "version": "9.26.0",
       "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
       "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
@@ -4788,56 +3488,6 @@
         "bip32": "^3.0.1",
         "bitcoin-ops": "^1.3.0",
         "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/unspents/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@bitgo/utxo-lib": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.23.0.tgz",
-      "integrity": "sha512-4+GjNKWbI2tQ68nXWWN6auukSLQvA7xifF1aacP1qN81cQUvZ5EzO+2JUj/M1U/wKDatDosLanIaNnFl3iy2xw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.6",
         "bn.js": "^5.2.1",
         "bs58check": "^2.1.2",
         "cashaddress": "^1.1.0",
@@ -4918,56 +3568,6 @@
         "lodash": "~4.17.21",
         "tcomb": "~3.2.29",
         "varuint-bitcoin": "^1.0.4"
-      }
-    },
-    "node_modules/@bitgo/utxo-ord/node_modules/@bitgo/utxo-lib": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/utxo-lib/-/utxo-lib-9.26.0.tgz",
-      "integrity": "sha512-qeePFZFehsfkBpUy64MRuFfjxU8aPoNaDmd6ZnWoLOUp450lPh1EUm3FbaoTN88GOG6gQB5t9kHnKMZBRSFkhw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@brandonblack/musig": "^0.0.1-alpha.0",
-        "@noble/secp256k1": "1.6.3",
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bip32": "^3.0.1",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoinjs-lib": "npm:@bitgo-forks/bitcoinjs-lib@7.1.0-master.7",
-        "bn.js": "^5.2.1",
-        "bs58check": "^2.1.2",
-        "cashaddress": "^1.1.0",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ecpair": "npm:@bitgo/ecpair@2.1.0-rc.0",
-        "elliptic": "^6.5.2",
-        "fastpriorityqueue": "^0.7.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10.22.0 <21",
-        "npm": ">=3.10.10"
-      }
-    },
-    "node_modules/@bitgo/utxo-ord/node_modules/bitcoinjs-lib": {
-      "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.7",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
-      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
-        "fastpriorityqueue": "^0.7.1",
-        "json5": "^2.2.3",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@bitgo/utxo-ord/node_modules/bs58": {
@@ -16957,9 +15557,9 @@
     },
     "node_modules/bitcoinjs-lib": {
       "name": "@bitgo-forks/bitcoinjs-lib",
-      "version": "7.1.0-master.6",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.6.tgz",
-      "integrity": "sha512-Cvf0odjJKy4frbcmVfTuRpQmAhu5wIFNmYNhJg3qxrV8pdR5WDbRICfGvrorxofZgB8Cv4UDTmbeoOF/ggmXnA==",
+      "version": "7.1.0-master.7",
+      "resolved": "https://registry.npmjs.org/@bitgo-forks/bitcoinjs-lib/-/bitcoinjs-lib-7.1.0-master.7.tgz",
+      "integrity": "sha512-FZle7954KnbbVXFCc5uYGtjq+0PFOnFxVchNwt3Kcv2nVusezTp29aeQwDi2Y+lM1dCoup2gJGXMkkREenY7KQ==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@bitgo/sdk-coin-xrp": "1.7.21",
     "@bitgo/sdk-coin-zec": "1.5.21",
     "@bitgo/sdk-coin-zeta": "1.19.0",
-    "@bitgo/utxo-lib": "9.23.0",
+    "@bitgo/utxo-lib": "9.26.0",
     "@ethereumjs/common": "2.6.5",
     "@lottiefiles/react-lottie-player": "3.4.9",
     "clsx": "1.2.1",


### PR DESCRIPTION
Older utxo-lib is used when compared to abstract-utxo dep. This causes version mistach issue that fails tbtc non bitgo recovery. Ticket: BTC-773