### PR TITLE
feat: automate the releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,218 @@
+name: on_pr_edit
+run-name: 'release: ${{ github.ref_name }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      next-version:
+        type: string
+        description: Semantic version of the new release to publish
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  get-current-state:
+    name: Get the current release state
+    runs-on: ubuntu-latest
+    env:
+      NEXT_VERSION: "${{ inputs.next-version }}"
+    outputs:
+      dmg_filename: "Wallet Recovery Wizard-${{ inputs.next-version }}.dmg"
+      exe_filename: "Wallet Recovery Wizard-Setup-${{ inputs.next-version }}.exe"
+      deb_filename: "Wallet Recovery Wizard-Linux-${{ inputs.next-version }}.deb"
+    steps:
+      - name: Verify the target branch
+        if: github.ref != 'refs/heads/master'
+        run: |
+          echo "This workflow should only run from the master branch"
+          exit 1
+
+      - run: |
+          if [[ ${{ env.NEXT_VERSION }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "The format of the next version is valid."
+          else
+            echo "Invalid format for the next version. Please provide a semantic release version number."
+            exit 1
+          fi
+
+      - name: Check if a release already exists for that version
+        run: |
+          current_release=$(
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ github.token }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/BitGo/wallet-recovery-wizard/releases/tags/v${{ env.NEXT_VERSION }}
+          )
+
+          current_release_name=$(echo "$current_release" | jq ".name")
+          if [[ -n "$current_release_name" ]]; then
+            echo "A release already exists for version ${{ env.NEXT_VERSION }}."
+            exit 1
+          fi
+
+  mac-build:
+    name: Create Mac release
+    runs-on: macos-latest
+    needs:
+      - get-current-state
+    env:
+      DMG_FILENAME: "${{ needs.get-current-state.outputs.dmg_filename }}"
+      NEXT_VERSION: "${{ inputs.next-version }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+      - run: |
+          sed -i -e 's/0.0.0-placeholder-version/${{ env.NEXT_VERSION }}/g' "package.json"
+          sed -i -e 's/0.0.0-placeholder-version/${{ env.NEXT_VERSION }}/g' "package-lock.json"
+      # TODO we should pin that version in the package-lock
+      - run: npm install dmg-license
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.DMG_FILENAME }}"
+          path: "release/${{ env.NEXT_VERSION }}/${{ env.DMG_FILENAME }}"
+          if-no-files-found: "error"
+
+  windows-linux-build:
+    name: Create Windows and Linux release
+    runs-on: ubuntu-latest
+    needs:
+      - get-current-state
+    env:
+      EXE_FILENAME: "${{ needs.get-current-state.outputs.exe_filename }}"
+      DEB_FILENAME: "${{ needs.get-current-state.outputs.deb_filename }}"
+      NEXT_VERSION: "${{ inputs.next-version }}"
+    container:
+      image: docker.io/electronuserland/builder:16-wine@sha256:a067f3efbc83d41f8a92f4bb347803e11ae0b29204520497edb3d34522d8d458
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          sed -i -e 's/0.0.0-placeholder-version/${{ env.NEXT_VERSION }}/g' "package.json"
+          sed -i -e 's/0.0.0-placeholder-version/${{ env.NEXT_VERSION }}/g' "package-lock.json"
+      - run: npm install
+      - run: npm run build -- -wl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.EXE_FILENAME }}"
+          path: "release/${{ env.NEXT_VERSION }}/${{ env.EXE_FILENAME }}"
+          if-no-files-found: "error"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.DEB_FILENAME }}"
+          path: "release/${{ env.NEXT_VERSION }}/${{ env.DEB_FILENAME }}"
+          if-no-files-found: "error"
+
+  create-new-release:
+    name: Create a new GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - get-current-state
+      - mac-build
+      - windows-linux-build
+    env:
+      DMG_FILENAME: "${{ needs.get-current-state.outputs.dmg_filename }}"
+      EXE_FILENAME: "${{ needs.get-current-state.outputs.exe_filename }}"
+      DEB_FILENAME: "${{ needs.get-current-state.outputs.deb_filename }}"
+      NEXT_VERSION: "${{ inputs.next-version }}"
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # We don't want to download the artifacts to separate directories,
+          # we want to download them to the same directory instead.
+          merge-multiple: true
+      - run: |
+          ls -la
+          sha256sum "${{ env.DMG_FILENAME }}" > "${{ env.DMG_FILENAME }}.sha256sum"
+          sha256sum "${{ env.DEB_FILENAME }}" > "${{ env.DEB_FILENAME }}.sha256sum"
+          sha256sum "${{ env.EXE_FILENAME }}" > "${{ env.EXE_FILENAME }}.sha256sum"
+
+      - name: Get the ID of the new release
+        id: get-new-release-id
+        run: |
+          new_release=$(curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/BitGo/wallet-recovery-wizard/releases \
+            -d '{"tag_name":"v${{ env.NEXT_VERSION }}","target_commitish":"${{ github.sha }}","name":"v${{ env.NEXT_VERSION }}","draft":true,"generate_release_notes":true}'
+          )
+          new_release_id=$(echo "$new_release" | jq ".id")
+          echo "new_release_id=$new_release_id" >> "$GITHUB_OUTPUT"
+          echo "new_release_id = $new_release_id"
+
+          new_release_url="https://uploads.github.com/repos/BitGo/wallet-recovery-wizard/releases/$new_release_id/assets"
+          echo "new_release_url=$new_release_url" >> "$GITHUB_OUTPUT"
+
+      - name: Add the Mac assets to the release
+        run: |
+          target_dmg_filename=$(echo "${{ env.DMG_FILENAME }}" | sed 's/\ /\./g')
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ steps.get-new-release-id.outputs.new_release_url }}?name=$target_dmg_filename" \
+            --data-binary "@${{ env.DMG_FILENAME }}"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ steps.get-new-release-id.outputs.new_release_url }}?name=$target_dmg_filename.sha256sum" \
+            --data-binary "@${{ env.DMG_FILENAME }}.sha256sum"
+
+      - name: Add the Linux assets to the release
+        run: |
+          target_deb_filename=$(echo "${{ env.DEB_FILENAME }}" | sed 's/\ /\./g')
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ steps.get-new-release-id.outputs.new_release_url }}?name=$target_deb_filename" \
+            --data-binary "@${{ env.DEB_FILENAME }}"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ steps.get-new-release-id.outputs.new_release_url }}?name=$target_deb_filename.sha256sum" \
+            --data-binary "@${{ env.DEB_FILENAME }}.sha256sum"
+
+      - name: Add the Windows assets to the release
+        run: |
+          target_exe_filename=$(echo "${{ env.EXE_FILENAME }}" | sed 's/\ /\./g')
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ steps.get-new-release-id.outputs.new_release_url }}?name=$target_exe_filename" \
+            --data-binary "@${{ env.EXE_FILENAME }}"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ steps.get-new-release-id.outputs.new_release_url }}?name=$target_exe_filename.sha256sum" \
+            --data-binary "@${{ env.EXE_FILENAME }}.sha256sum"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wallet-recovery-wizard",
-  "version": "4.22.0",
+  "version": "0.0.0-placeholder-version",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wallet-recovery-wizard",
-      "version": "4.22.0",
+      "version": "0.0.0-placeholder-version",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitgo/abstract-cosmos": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "storybook:test:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npx start-storybook --ci -p 6006\" \"wait-on http-get://localhost:6006/ && npx test-storybook\"",
     "test": "vitest"
   },
-  "version": "4.22.0",
+  "version": "0.0.0-placeholder-version",
   "overrides": {
     "@polkadot/api": "10.9.1",
     "@polkadot/x-fetch": "12.3.2",


### PR DESCRIPTION
This PR adds a workflow that automates the releases to GitHub. The workflow is manually triggered, and the next semantic version must be provided when triggering the workflow. The new release will be left as a draft after the workflow has completed, so that the repo maintainer can review the release and publish it. No new commit will be pushed by the release workflow, and the new git tag will be created by GitHub when creating the new release.

I still need to update the release documentation in `DEVELOPER.md`, but I think this can happen in a future PR, after I have tested the new workflow against the master branch. 