### PR TITLE
refactor(root): rename tokenAddress to tokenContractAddress

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -236,7 +236,7 @@ async function createWindow() {
           break;
         case 'avaxc':
         case 'tavaxc':
-          sdk = new BitGoAPI({ env: environment, snowtraceApiToken: apiKey });
+          sdk = new BitGoAPI({ env: environment });
           break;
         case 'arbeth':
         case 'tarbeth':
@@ -244,7 +244,10 @@ async function createWindow() {
           break;
         case 'opeth':
         case 'topeth':
-          sdk = new BitGoAPI({ env: environment, optimisticEtherscanApiToken: apiKey });
+          sdk = new BitGoAPI({
+            env: environment,
+            optimisticEtherscanApiToken: apiKey,
+          });
           break;
         case 'polygon':
         case 'tpolygon':

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -53,7 +53,7 @@ type Commands = {
     | AdaRecoveryConsolidationRecoveryBatch
     | DotRecoverConsolidationRecoveryBatch
     | SolRecoverConsolidationRecoveryBatch
-  >,
+  >;
   writeFile(
     file: string,
     data: string,
@@ -84,7 +84,7 @@ type Commands = {
         publicKey: string;
         secretKey: string;
       };
-      tokenAddress?: string;
+      tokenContractAddress?: string;
       startingScanIndex?: number;
     }
   ): Promise<BackupKeyRecoveryTransansaction | FormattedOfflineVaultTxInfo>;

--- a/src/containers/BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx
@@ -17,7 +17,7 @@ const validationSchema = Yup.object({
     .positive('Gas price must be a positive integer')
     .required(),
   recoveryDestination: Yup.string().required(),
-  tokenAddress: Yup.string().required(),
+  tokenContractAddress: Yup.string().required(),
   userKey: Yup.string().required(),
   userKeyId: Yup.string(),
   walletContractAddress: Yup.string().required(),
@@ -41,7 +41,7 @@ export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
       gasLimit: 500000,
       gasPrice: 30,
       recoveryDestination: '',
-      tokenAddress: '',
+      tokenContractAddress: '',
       userKey: '',
       userKeyId: '',
       walletContractAddress: '',
@@ -99,7 +99,7 @@ export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
           <FormikTextfield
             HelperText="The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address."
             Label="Token Contract Address"
-            name="tokenAddress"
+            name="tokenContractAddress"
             Width="fill"
           />
         </div>

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -342,13 +342,12 @@ function Form() {
               await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
               const parentCoin = env === 'test' ? 'tavaxc' : 'avaxc';
               const chainData = await getTokenChain(
-                values.tokenAddress.toLowerCase(),
+                values.tokenContractAddress.toLowerCase(),
                 parentCoin
               );
               const recoverData = await window.commands.recover(parentCoin, {
                 ...(await updateKeysFromIds(coin, values)),
-                //TODO(WP-1221): remove and use tokenAddress instead
-                tokenContractAddress: values.tokenAddress.toLowerCase(),
+                tokenContractAddress: values.tokenContractAddress.toLowerCase(),
                 gasPrice: toWei(values.gasPrice),
                 bitgoKey: '',
                 ignoreAddressTypes: [],
@@ -379,7 +378,7 @@ function Form() {
                     ? {
                         ...recoverData,
                         ...(await includePubsForToken(
-                          values.tokenAddress.toLowerCase(),
+                          values.tokenContractAddress.toLowerCase(),
                           coin,
                           values
                         )),
@@ -830,18 +829,18 @@ function Form() {
               );
               const parentCoin = env === 'test' ? 'hteth' : 'eth';
               const chainData = await getTokenChain(
-                values.tokenAddress.toLowerCase(),
+                values.tokenContractAddress.toLowerCase(),
                 parentCoin
               );
               const { maxFeePerGas, maxPriorityFeePerGas, ...rest } =
                 await updateKeysFromIdsWithToken(
-                  values.tokenAddress.toLowerCase(),
+                  values.tokenContractAddress.toLowerCase(),
                   parentCoin,
                   values
                 );
 
               const recoverData = await recoverWithToken(
-                values.tokenAddress.toLowerCase(),
+                values.tokenContractAddress.toLowerCase(),
                 parentCoin,
                 {
                   ...rest,
@@ -881,13 +880,13 @@ function Form() {
                 JSON.stringify(
                   includePubsInUnsignedSweep
                     ? {
-                      ...recoverData,
-                      ...(await includePubsForToken(
-                        values.tokenAddress.toLowerCase(),
-                        coin,
-                        values
-                      )),
-                    }
+                        ...recoverData,
+                        ...(await includePubsForToken(
+                          values.tokenContractAddress.toLowerCase(),
+                          coin,
+                          values
+                        )),
+                      }
                     : recoverData,
                   null,
                   2

--- a/src/containers/BuildUnsignedSweepCoin/Erc20TokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/Erc20TokenForm.tsx
@@ -15,7 +15,7 @@ const validationSchema = Yup.object({
   maxFeePerGas: Yup.number().required(),
   maxPriorityFeePerGas: Yup.number().required(),
   recoveryDestination: Yup.string().required(),
-  tokenAddress: Yup.string().required(),
+  tokenContractAddress: Yup.string().required(),
   userKey: Yup.string().required(),
   userKeyId: Yup.string(),
   walletContractAddress: Yup.string().required(),
@@ -41,7 +41,7 @@ export function Erc20TokenForm({ onSubmit }: Erc20TokenFormProps) {
       maxFeePerGas: 20,
       maxPriorityFeePerGas: 10,
       recoveryDestination: '',
-      tokenAddress: '',
+      tokenContractAddress: '',
       userKey: '',
       userKeyId: '',
       walletContractAddress: '',
@@ -99,7 +99,7 @@ export function Erc20TokenForm({ onSubmit }: Erc20TokenFormProps) {
           <FormikTextfield
             HelperText="The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address."
             Label="Token Contract Address"
-            name="tokenAddress"
+            name="tokenContractAddress"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/AvalancheCTokenForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/AvalancheCTokenForm.tsx
@@ -24,7 +24,7 @@ const validationSchema = Yup.object({
     .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
     .label('Key Recovery Service'),
   recoveryDestination: Yup.string().required(),
-  tokenAddress: Yup.string().required(),
+  tokenContractAddress: Yup.string().required(),
   userKey: Yup.string().required(),
   walletContractAddress: Yup.string().required(),
   walletPassphrase: Yup.string().required(),
@@ -45,7 +45,7 @@ export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
     initialValues: {
       userKey: '',
       backupKey: '',
-      tokenAddress: '',
+      tokenContractAddress: '',
       walletContractAddress: '',
       walletPassphrase: '',
       recoveryDestination: '',
@@ -110,7 +110,7 @@ export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
           <FormikTextfield
             HelperText="The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address."
             Label="Token Contract Address"
-            name="tokenAddress"
+            name="tokenContractAddress"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/Erc20TokenForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/Erc20TokenForm.tsx
@@ -18,7 +18,7 @@ const validationSchema = Yup.object({
   maxFeePerGas: Yup.number().required(),
   maxPriorityFeePerGas: Yup.number().required(),
   recoveryDestination: Yup.string().required(),
-  tokenAddress: Yup.string().required(),
+  tokenContractAddress: Yup.string().required(),
   userKey: Yup.string().required(),
   walletContractAddress: Yup.string().required(),
   walletPassphrase: Yup.string().required(),
@@ -40,7 +40,7 @@ export function Erc20TokenForm({ onSubmit }: Erc20TokenFormProps) {
       apiKey: '',
       userKey: '',
       backupKey: '',
-      tokenAddress: '',
+      tokenContractAddress: '',
       walletContractAddress: '',
       walletPassphrase: '',
       recoveryDestination: '',
@@ -106,7 +106,7 @@ export function Erc20TokenForm({ onSubmit }: Erc20TokenFormProps) {
           <FormikTextfield
             HelperText="The address of the smart contract of the token to recover. This is unique to each token, and is NOT your wallet address."
             Label="Token Contract Address"
-            name="tokenAddress"
+            name="tokenContractAddress"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -471,13 +471,12 @@ function Form() {
               await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
               const parentCoin = env === 'test' ? 'tavaxc' : 'avaxc';
               const chainData = await getTokenChain(
-                values.tokenAddress.toLowerCase(),
+                values.tokenContractAddress.toLowerCase(),
                 parentCoin
               );
               const recoverData = await window.commands.recover(parentCoin, {
                 ...values,
-                //TODO(WP-1221): remove and use tokenAddress instead
-                tokenContractAddress: values.tokenAddress.toLowerCase(),
+                tokenContractAddress: values.tokenContractAddress.toLowerCase(),
                 gasPrice: toWei(values.gasPrice),
                 bitgoKey: '',
                 ignoreAddressTypes: [],
@@ -962,13 +961,13 @@ function Form() {
               );
               const parentCoin = env === 'test' ? 'hteth' : 'eth';
               const chainData = await getTokenChain(
-                values.tokenAddress.toLowerCase(),
+                values.tokenContractAddress.toLowerCase(),
                 parentCoin
               );
               const { maxFeePerGas, maxPriorityFeePerGas, ...rest } = values;
 
               const recoverData = await recoverWithToken(
-                values.tokenAddress.toLowerCase(),
+                values.tokenContractAddress.toLowerCase(),
                 parentCoin,
                 {
                   ...rest,

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -75,7 +75,7 @@ type Commands = {
         maxPriorityFeePerGas: number;
       };
       replayProtectionOptions?: {
-        chain: 10001 | typeof Chain[keyof typeof Chain];
+        chain: 10001 | 17000 | typeof Chain[keyof typeof Chain];
         hardfork: `${Hardfork}`;
       };
       walletContractAddress?: string;
@@ -83,8 +83,6 @@ type Commands = {
         publicKey: string;
         secretKey: string;
       };
-      tokenAddress?: string;
-      //TODO(WP-1221): remove and use tokenAddress instead
       tokenContractAddress?: string;
       startingScanIndex?: number;
       seed?: string;


### PR DESCRIPTION
renamed tokenAddress to tokenContractAddress since tokenAddress is not an param for the sdk recover method

WP-1221

[AVAXC testnet token recovery tx:](https://testnet.snowtrace.io/tx/0x3eecb54ddb15c61537c8e54e4138a0190cc7c84d41f43c4418644e6904a947f2?chainId=43113)
[ETH Holesky token recovery tx](https://holesky.beaconcha.in/tx/0x401c74b60c2cbc9f6f8d8aadcb68c4e0e875517b8ae2b008e44dfae57e8861c1)