### PR TITLE
feat: use nvmrc node version in gha

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.10.0'
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.10.0'
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.10.0'
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This will make sure that the node version is in sync in all the GHA workflows.