### PR TITLE
fix: rename release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: on_pr_edit
+name: release
 run-name: 'release: ${{ github.ref_name }}'
 
 on:


### PR DESCRIPTION
This is just a copy-pasta from another workflow which I used as a template.