### PR TITLE
fix: do not publish using electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "name": "wallet-recovery-wizard",
   "private": true,
   "scripts": {
-    "build": "tsc && vite build && electron-builder",
+    "build": "tsc && vite build && electron-builder --publish never",
     "dev": "vite",
     "durable-nonce:build": "node ./scripts/build-durable-nonce",
     "eth-eip1559:decode": "node ./scripts/decode-eth-eip1559",


### PR DESCRIPTION
Apparently, `electron-builder` will change the default `--publish` behavior when running from the `master` branch in GitHub Actions ([see this thread](https://github.com/electron-userland/electron-builder/issues/1693)), and will try to publish a draft release after building the project. This is not wanted, since we will publish the artifact later in the workflow when we have all the artifacts available. 