### PR TITLE
feat: add flow for sweeping funds from a V1 BTC wallet

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -434,10 +434,8 @@ async function createWindow() {
       switch (coin) {
         case 'btc':
         case 'tbtc': {
-          const coinInstance = sdk.coin(coin) as
-            | Btc
-            | Tbtc
-          return coinInstance.sweepV1(parameters);
+          const coinInstance = sdk.coin(coin) as AbstractUtxoCoin;
+          return await coinInstance.sweepV1(parameters);
         }
         default:
           return new Error(

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -427,6 +427,25 @@ async function createWindow() {
       }
     }
   );
+
+  ipcMain.handle(
+    'sweepV1',
+    async (event, coin, parameters) => {
+      switch (coin) {
+        case 'btc':
+        case 'tbtc': {
+          const coinInstance = sdk.coin(coin) as
+            | Btc
+            | Tbtc
+          return coinInstance.sweepV1(parameters);
+        }
+        default:
+          return new Error(
+            `Coin: ${coin} does not support v1 wallets sweep`
+          );
+      }
+    }
+  );
 }
 
 void app.whenReady().then(createWindow);

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -428,6 +428,11 @@ async function createWindow() {
     }
   );
 
+  ipcMain.handle('unlock', async (event, otp) => {
+    const response = await sdk.unlock({ otp });
+    return response;
+  });
+
   ipcMain.handle(
     'sweepV1',
     async (event, coin, parameters) => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -46,6 +46,7 @@ type Commands = {
       | createDotBroadcastableSweepTransactionParameters
       | createSolBroadcastableSweepTransactionParameters
   ): Promise<Error | BroadcastableSweepTransaction>;
+  unlock(otp: string);
   sweepV1(coin: string, parameters);
   recoverConsolidations(
     coin: string,
@@ -159,6 +160,9 @@ const commands: Commands = {
       coin,
       parameters
     );
+  },
+  unlock(otp: string) {
+    return ipcRenderer.invoke('unlock', otp);
   },
   sweepV1(coin, parameters) {
     return ipcRenderer.invoke('sweepV1', coin, parameters);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -46,6 +46,7 @@ type Commands = {
       | createDotBroadcastableSweepTransactionParameters
       | createSolBroadcastableSweepTransactionParameters
   ): Promise<Error | BroadcastableSweepTransaction>;
+  sweepV1(coin: string, parameters);
   recoverConsolidations(
     coin: string,
     params:
@@ -158,6 +159,9 @@ const commands: Commands = {
       coin,
       parameters
     );
+  },
+  sweepV1(coin, parameters) {
+    return ipcRenderer.invoke('sweepV1', coin, parameters);
   },
   recoverConsolidations(
     coin: string,

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -15,6 +15,7 @@ import { CreateBroadcastableTransactionIndex } from '~/containers/CreateBroadcas
 import { BroadcastTransactionIndex } from './BroadcastTransactionIndex';
 import { SuccessfulBroadcastTransaction } from './SuccessfulBroadcastTransaction';
 import { BroadcastTransactionCoin } from './BroadcastTransactionCoin';
+import {V1BtcSweep} from "~/containers/V1BtcSweep";
 
 export default function App() {
   return (
@@ -112,6 +113,18 @@ export default function App() {
         }
       >
         <Route index element={<WrongChainRecovery />} />
+        <Route path=":coin/success" element={<SuccessfulRecovery />} />
+      </Route>
+      <Route
+        path="/:env/v1btc-sweep"
+        element={
+          <AuthenticatedPageLayout
+            Title="V1BTC Sweep"
+            Description="Create a full-signed sweep transaction using User and BitGo key."
+          />
+        }
+      >
+        <Route index element={<V1BtcSweep />} />
         <Route path=":coin/success" element={<SuccessfulRecovery />} />
       </Route>
     </Routes>

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -115,6 +115,12 @@ export function Home() {
                   Title="Wrong Chain Recoveries"
                   Description="Recover funds sent to the wrong chain, such as BTC sent to a LTC address."
                 />
+                <LinkCardItem
+                  Tag={Link}
+                  to={`/${env}/v1btc-sweep`}
+                  Title="V1BTC Sweep"
+                  Description="Create a full-signed sweep transaction using User and BitGo key."
+                />
               </LinkCard>
             </div>
           </div>

--- a/src/containers/V1BtcSweep/V1BtcSweepForm.tsx
+++ b/src/containers/V1BtcSweep/V1BtcSweepForm.tsx
@@ -10,6 +10,7 @@ const validationSchema = Yup.object({
   unspents: Yup.mixed().required(),
   destinationAddress: Yup.string().required(),
   encryptedUserKey: Yup.string().required(),
+  otp: Yup.string().required(),
 }).required();
 
 export type V1BtcSweepFormProps = {
@@ -30,6 +31,7 @@ export function V1BtcSweepForm({onSubmit}: V1BtcSweepFormProps) {
       unspents: undefined,
       destinationAddress: '',
       encryptedUserKey: '',
+      otp: '',
     },
     validationSchema,
   });
@@ -80,6 +82,14 @@ export function V1BtcSweepForm({onSubmit}: V1BtcSweepFormProps) {
                 .setFieldValue('unspents', event.currentTarget.files?.[0])
                 .catch(console.error);
             }}
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText={`2FA`}
+            Label="2FA Code"
+            name="otp"
+            Width="fill"
           />
         </div>
 

--- a/src/containers/V1BtcSweep/V1BtcSweepForm.tsx
+++ b/src/containers/V1BtcSweep/V1BtcSweepForm.tsx
@@ -1,0 +1,103 @@
+import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
+import { Link } from 'react-router-dom';
+import * as Yup from 'yup';
+import { Button, FormikPasswordfield, FormikTextfield } from '~/components';
+import { FormikFilefield } from "~/components/FormikFilefield";
+
+const validationSchema = Yup.object({
+  walletId: Yup.string().required(),
+  walletPassphrase: Yup.string().required(),
+  unspents: Yup.mixed().required(),
+  destinationAddress: Yup.string().required(),
+  encryptedUserKey: Yup.string().required(),
+}).required();
+
+export type V1BtcSweepFormProps = {
+  onSubmit: (
+    values: V1BtcSweepFormValues,
+    formikHelpers: FormikHelpers<V1BtcSweepFormValues>
+  ) => void | Promise<void>;
+};
+
+type V1BtcSweepFormValues = Yup.Asserts<typeof validationSchema>;
+
+export function V1BtcSweepForm({onSubmit}: V1BtcSweepFormProps) {
+  const formik = useFormik<V1BtcSweepFormValues>({
+    onSubmit,
+    initialValues: {
+      walletId: '',
+      walletPassphrase: '',
+      unspents: undefined,
+      destinationAddress: '',
+      encryptedUserKey: '',
+    },
+    validationSchema,
+  });
+
+  return (
+    <FormikProvider value={formik}>
+      <Form>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText={`This is the wallet ID of the wallet from where to sweep.`}
+            Label="Wallet ID"
+            name="walletId"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikPasswordfield
+            HelperText={`The wallet passphrase of the wallet from where to sweep.`}
+            Label="Wallet Passphrase"
+            name="walletPassphrase"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText={`The encrypted user private key for the wallet.`}
+            Label="Encrypted User Private Key"
+            name="encryptedUserKey"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText={`The address your sweep transaction will send to.`}
+            Label="Destination Address"
+            name="destinationAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikFilefield
+            name="tx"
+            accept=".json"
+            Width="fill"
+            Label="Upload unspents file"
+            onChange={event => {
+              formik
+                .setFieldValue('unspents', event.currentTarget.files?.[0])
+                .catch(console.error);
+            }}
+          />
+        </div>
+
+        <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
+          <Button Tag={Link} to="/" Variant="secondary" Width="hug">
+            Cancel
+          </Button>
+          <Button
+            Variant="primary"
+            Width="hug"
+            type="submit"
+            Disabled={formik.isSubmitting}
+            disabled={formik.isSubmitting}
+          >
+            {formik.isSubmitting ? 'Sweeping...' : 'Sweep Funds'}
+          </Button>
+        </div>
+      </Form>
+    </FormikProvider>
+  );
+}

--- a/src/containers/V1BtcSweep/index.tsx
+++ b/src/containers/V1BtcSweep/index.tsx
@@ -36,6 +36,7 @@ export function V1BtcSweep() {
           try {
             const unspents = JSON.parse(event.target?.result as string) as BitGoV1Unspent[];
             setSubmitting(true);
+            await window.commands.unlock(values.otp);
             const chainData = await window.queries.getChain(coin);
             const result = await window.commands.sweepV1(coin, {
               walletId: values.walletId,
@@ -68,14 +69,14 @@ export function V1BtcSweep() {
               `/${environment}/v1btc-sweep/${coin}/success`
             );
           } catch (error) {
+            setSubmitting(false);
+            console.log(error);
             if (error instanceof Error) {
-              setFieldError('unspents', error.message);
               setAlert(error.message);
-            } else {
-              console.log(error);
             }
+          } finally {
+            setSubmitting(false);
           }
-          setSubmitting(false);
         };
 
       }}

--- a/src/containers/V1BtcSweep/index.tsx
+++ b/src/containers/V1BtcSweep/index.tsx
@@ -1,0 +1,84 @@
+import {useNavigate, useParams} from 'react-router-dom';
+import {useAlertBanner} from '~/contexts';
+import {safeEnv} from '~/helpers';
+import {V1BtcSweepForm} from "~/containers/V1BtcSweep/V1BtcSweepForm";
+import { BitGoV1Unspent } from "@bitgo/abstract-utxo";
+
+
+export function V1BtcSweep() {
+  const {env} = useParams<'env'>();
+  const navigate = useNavigate();
+  const [_, setAlert] = useAlertBanner();
+
+  const environment = safeEnv(env);
+  const coin = env === 'test' ? 'tbtc' : 'btc';
+
+  return (
+    <V1BtcSweepForm
+      onSubmit={async (values, {setFieldError, setSubmitting}) => {
+        if (!values.unspents) {
+          setAlert('Unspents file is required');
+          return;
+        }
+
+        setAlert(undefined);
+        const isSdkAuth = await window.queries.isSdkAuthenticated();
+        if (!isSdkAuth) {
+          setAlert('Not logged in');
+          setSubmitting(false);
+          navigate(`/${environment}/v1btc-sweep`);
+          return;
+        }
+
+        const fileReader = new FileReader();
+        fileReader.readAsText(values.unspents, 'UTF-8');
+        fileReader.onload = async event => {
+          try {
+            const unspents = JSON.parse(event.target?.result as string) as BitGoV1Unspent[];
+            setSubmitting(true);
+            const chainData = await window.queries.getChain(coin);
+            const result = await window.commands.sweepV1(coin, {
+              walletId: values.walletId,
+              walletPassphrase: values.walletPassphrase,
+              recoveryDestination: values.destinationAddress,
+              userKey: values.encryptedUserKey,
+              unspents,
+            });
+            setSubmitting(false);
+
+            const showSaveDialogData = await window.commands.showSaveDialog({
+              filters: [
+                {
+                  name: 'Custom File Type',
+                  extensions: ['json'],
+                },
+              ],
+              defaultPath: `~/${chainData}-fullsigned-tx-${Date.now()}.json`,
+            });
+            if (!showSaveDialogData.filePath) {
+              throw new Error('No file path selected');
+            }
+
+            await window.commands.writeFile(
+              showSaveDialogData.filePath,
+              JSON.stringify(result, null, 2),
+              { encoding: 'utf8' }
+            );
+            navigate(
+              `/${environment}/v1btc-sweep/${coin}/success`
+            );
+          } catch (error) {
+            if (error instanceof Error) {
+              setFieldError('unspents', error.message);
+              setAlert(error.message);
+            } else {
+              console.log(error);
+            }
+          }
+          setSubmitting(false);
+        };
+
+      }}
+    />
+  );
+}

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -45,6 +45,7 @@ type Commands = {
       | createDotBroadcastableSweepTransactionParameters
       | createSolBroadcastableSweepTransactionParameters
   ): Promise<Error | BroadcastableSweepTransaction>;
+  unlock(otp: string);
   sweepV1(coin: string, parameters);
   recoverConsolidations(
     coin: string,

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -45,6 +45,7 @@ type Commands = {
       | createDotBroadcastableSweepTransactionParameters
       | createSolBroadcastableSweepTransactionParameters
   ): Promise<Error | BroadcastableSweepTransaction>;
+  sweepV1(coin: string, parameters);
   recoverConsolidations(
     coin: string,
     params:


### PR DESCRIPTION
feat: add flow for sweeping funds from a V1 BTC wallet

Given a list of unspents to sweep.

BTC-1224

Ended up creating 2 full signed transactions using this flow for my v1safe wallet, Redash query below:
```
{
    "collection": "wallettx",
    "query": {
        "walletId": "2N85TyC2JdbBpanfme6w8XNQaSr5wcc9Ry9"
    },
    "limit": 2,
    "sort": [{
        "name": "createdDate",
        "direction": -1
    }]
}
```
<img width="1430" alt="Screenshot 2024-07-17 at 5 58 11 PM" src="https://github.com/user-attachments/assets/73118c76-d8be-4535-900e-ce91351360e4">


WRW Flow
<img width="1728" alt="Screenshot 2024-07-15 at 2 42 02 PM" src="https://github.com/user-attachments/assets/abdf6b67-be77-4f3e-a502-f605b7c89a7b">
<img width="1728" alt="Screenshot 2024-07-15 at 2 42 22 PM" src="https://github.com/user-attachments/assets/1a7596c0-dd57-46b4-aa37-088b83069c1f">
<img width="1728" alt="Screenshot 2024-07-15 at 2 43 05 PM" src="https://github.com/user-attachments/assets/2ccf5ae1-7467-4508-b82f-917db2215fd7">
<img width="1728" alt="Screenshot 2024-07-15 at 2 43 23 PM" src="https://github.com/user-attachments/assets/0e061fd5-9044-48e6-a481-639024fc737d">
<img width="1728" alt="Screenshot 2024-07-15 at 2 43 35 PM" src="https://github.com/user-attachments/assets/1cace6dd-0ec8-4d8c-82d1-5b7734ea0139">
<img width="799" alt="Screenshot 2024-07-17 at 3 05 31 PM" src="https://github.com/user-attachments/assets/8b80cacc-3e3b-40c5-8c14-0ac2ec0019d2">
<img width="798" alt="Screenshot 2024-07-17 at 3 05 51 PM" src="https://github.com/user-attachments/assets/bf8d40a4-3aab-444c-9c7a-61c4d62487f4">
<img width="1289" alt="Screenshot 2024-07-17 at 4 23 42 PM" src="https://github.com/user-attachments/assets/b7dafea3-dc59-471f-8008-244ac1bcaef7">

