### PR TITLE
fix: DI openSSLBytes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@bitgo/sdk-coin-xrp": "2.1.15",
         "@bitgo/sdk-coin-zec": "2.0.34",
         "@bitgo/sdk-coin-zeta": "3.0.3",
+        "@bitgo/sdk-opensslbytes": "^2.0.0",
         "@bitgo/utxo-lib": "10.3.0",
         "@ethereumjs/common": "2.6.5",
         "@lottiefiles/react-lottie-player": "3.4.9",
@@ -4715,6 +4716,11 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@bitgo/sdk-opensslbytes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bitgo/sdk-opensslbytes/-/sdk-opensslbytes-2.0.0.tgz",
+      "integrity": "sha512-xJBVWT2Rr6BwGyMiQOYxqVOoBFAEdK6SVBWSSXaGk76ONbLR9YTI0meS0qB8esrTmrd9tn0H/9JRUpNeIN3/pg=="
     },
     "node_modules/@bitgo/sjcl": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@bitgo/abstract-cosmos": "11.0.3",
     "@bitgo/abstract-utxo": "8.14.0",
+    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-api": "1.53.3",
     "@bitgo/sdk-coin-ada": "4.2.12",
     "@bitgo/sdk-coin-algo": "2.1.32",


### PR DESCRIPTION
This PR unblocks recovery for ECDSA tss coins. A recent SDK change requires openSSLBytes to be dependency injected into the recover method.

In future prs we will remove opensslbytes all together from the TSS recovery flow.