### PR TITLE
feat: remove p2wsh from ignored address types

### DIFF
--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -70,7 +70,7 @@ function Form() {
                 ...(await updateKeysFromIds(coin, values)),
                 scan: Number(values.scan),
                 feeRate: values.feeRate ? Number(values.feeRate) : undefined,
-                ignoreAddressTypes: ['p2wsh'],
+                ignoreAddressTypes: [],
               });
 
               assert(


### PR DESCRIPTION
I don't know why this was there in the first place.

Ticket: BTC-2130