### PR TITLE
chore: removing redundant code for generating broadcastable tx

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -517,76 +517,8 @@ async function createWindow() {
   ipcMain.handle(
     'createBroadcastableSweepTransaction',
     async (event, coin, parameters) => {
-      switch (coin) {
-        // Temporary measure till this is refactored into Basecoin
-        case 'ada':
-        case 'tada':
-        case 'dot':
-        case 'tdot':
-        case 'tao':
-        case 'ttao':
-        case 'sol':
-        case 'tsol':
-        case 'sui':
-        case 'tsui':
-        case 'icp':
-        case 'ticp':
-        case 'tnear':
-        case 'near':
-        case 'flr':
-        case 'tflr':
-        case 'wemix':
-        case 'twemix':
-        case 'sgb':
-        case 'tsgb':
-        case 'xdc':
-        case 'txdc':
-        case 'oas':
-        case 'toas':
-        case 'coredao':
-        case 'tcoredao':
-        case 'eth':
-        case 'hteth':
-        case 'polygon':
-        case 'tpolygon':{
-          const coinInstance = sdk.coin(coin) as
-            | Ada
-            | Tada
-            | Dot
-            | Tdot
-            | Tao
-            | Ttao
-            | Sol
-            | Tsol
-            | Sui
-            | Tsui
-            | Icp
-            | Ticp
-            | Near
-            | TNear
-            | Eth
-            | Hteth
-            | Flr
-            | Tflr
-            | Wemix
-            | Twemix
-            | Sgb
-            | Tsgb
-            | Xdc
-            | Txdc
-            | Oas
-            | Toas
-            | Coredao
-            | Tcoredao
-            | Polygon
-            | Tpolygon;
-          return coinInstance.createBroadcastableSweepTransaction(parameters);
-        }
-        default:
-          return new Error(
-            `Coin: ${coin} does not support creating a broadcastable creation`
-          );
-      }
+      const coinInstance = sdk.coin(coin) as BaseCoin;
+      return coinInstance.createBroadcastableSweepTransaction(parameters);
     }
   );
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -25,20 +25,6 @@ import {
   BroadcastableSweepTransaction,
   BroadcastTransactionResult,
   BroadcastTransactionOptions,
-  createAdaBroadcastableSweepTransactionParameters,
-  createDotBroadcastableSweepTransactionParameters,
-  createTaoBroadcastableSweepTransactionParameters,
-  createSolBroadcastableSweepTransactionParameters,
-  createSuiBroadcastableSweepTransactionParameters,
-  createNearBroadcastableSweepTransactionParameters,
-  createEthBroadcastableSweepTransactionParameters,
-  createFlrBroadcastableSweepTransactionParameters,
-  createWemixBroadcastableSweepTransactionParameters,
-  createXdcBroadcastableSweepTransactionParameters,
-  createOasBroadcastableSweepTransactionParameters,
-  createCoredaoBroadcastableSweepTransactionParameters,
-  createSgbBroadcastableSweepTransactionParameters,
-  createpolygonBroadcastableSweepTransactionParameters,
   DotRecoverConsolidationRecoveryBatch,
   DotRecoveryConsolidationRecoveryOptions,
   TaoRecoverConsolidationRecoveryBatch,
@@ -47,11 +33,11 @@ import {
   SolRecoveryConsolidationRecoveryOptions,
   SuiRecoverConsolidationRecoveryBatch,
   SuiRecoveryConsolidationRecoveryOptions,
-  createIcpBroadcastableSweepTransactionParameters,
 } from '../types';
 
 import type * as EthLikeCommon from '@ethereumjs/common';
 import { EvmCcrNonBitgoCoinConfigType } from '../../src/helpers/config';
+import { MPCSweepRecoveryOptions } from '@bitgo/sdk-core';
 
 type User = { username: string };
 
@@ -62,22 +48,7 @@ type Commands = {
   ): Promise<Error | BroadcastTransactionResult>;
   createBroadcastableSweepTransaction(
     coin: string,
-    parameters:
-      | createAdaBroadcastableSweepTransactionParameters
-      | createDotBroadcastableSweepTransactionParameters
-      | createTaoBroadcastableSweepTransactionParameters
-      | createSolBroadcastableSweepTransactionParameters
-      | createSuiBroadcastableSweepTransactionParameters
-      | createIcpBroadcastableSweepTransactionParameters
-      | createNearBroadcastableSweepTransactionParameters
-      | createEthBroadcastableSweepTransactionParameters
-      | createFlrBroadcastableSweepTransactionParameters
-      | createWemixBroadcastableSweepTransactionParameters
-      | createXdcBroadcastableSweepTransactionParameters
-      | createSgbBroadcastableSweepTransactionParameters
-      | createOasBroadcastableSweepTransactionParameters
-      | createCoredaoBroadcastableSweepTransactionParameters
-      | createpolygonBroadcastableSweepTransactionParameters
+    parameters: MPCSweepRecoveryOptions
   ): Promise<Error | BroadcastableSweepTransaction>;
   unlock(otp: string);
   sweepV1(coin: string, parameters: V1SweepParams): ReturnType<typeof v1Sweep>;

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -20,52 +20,6 @@ import { Oas, Toas } from '@bitgo/sdk-coin-oas';
 import { Coredao, Tcoredao } from '@bitgo/sdk-coin-coredao';
 import { Polygon, Tpolygon } from '@bitgo/sdk-coin-polygon';
 
-export type createAdaBroadcastableSweepTransactionParameters =
-  | Parameters<Ada['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tada['createBroadcastableSweepTransaction']>[0];
-export type createDotBroadcastableSweepTransactionParameters =
-  | Parameters<Dot['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tdot['createBroadcastableSweepTransaction']>[0];
-export type createTaoBroadcastableSweepTransactionParameters =
-  | Parameters<Tao['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Ttao['createBroadcastableSweepTransaction']>[0];
-export type createSolBroadcastableSweepTransactionParameters =
-  | Parameters<Sol['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tsol['createBroadcastableSweepTransaction']>[0];
-export type createSuiBroadcastableSweepTransactionParameters =
-  | Parameters<Sui['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tsui['createBroadcastableSweepTransaction']>[0];
-export type createIcpBroadcastableSweepTransactionParameters =
-  | Parameters<Icp['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Ticp['createBroadcastableSweepTransaction']>[0];
-export type createNearBroadcastableSweepTransactionParameters =
-  | Parameters<Near['createBroadcastableSweepTransaction']>[0]
-  | Parameters<TNear['createBroadcastableSweepTransaction']>[0];
-export type createEthBroadcastableSweepTransactionParameters =
-  | Parameters<Eth['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Hteth['createBroadcastableSweepTransaction']>[0];
-export type createFlrBroadcastableSweepTransactionParameters =
-  | Parameters<Flr['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tflr['createBroadcastableSweepTransaction']>[0];
-export type createWemixBroadcastableSweepTransactionParameters =
-  | Parameters<Wemix['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Twemix['createBroadcastableSweepTransaction']>[0];
-export type createSgbBroadcastableSweepTransactionParameters =
-  | Parameters<Sgb['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tsgb['createBroadcastableSweepTransaction']>[0];
-export type createXdcBroadcastableSweepTransactionParameters =
-  | Parameters<Xdc['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Txdc['createBroadcastableSweepTransaction']>[0];
-export type createOasBroadcastableSweepTransactionParameters =
-  | Parameters<Oas['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Toas['createBroadcastableSweepTransaction']>[0];
-export type createCoredaoBroadcastableSweepTransactionParameters =
-  | Parameters<Coredao['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tcoredao['createBroadcastableSweepTransaction']>[0];
-export type createpolygonBroadcastableSweepTransactionParameters =
-  | Parameters<Polygon['createBroadcastableSweepTransaction']>[0]
-  | Parameters<Tpolygon['createBroadcastableSweepTransaction']>[0];
-
 export type BroadcastableSweepTransaction = Awaited<
   ReturnType<
     | Ada['createBroadcastableSweepTransaction']
@@ -90,22 +44,6 @@ export type BroadcastTransactionOptions = Awaited<
   | Parameters<Tsui['broadcastTransaction']>[0]
   | Parameters<Near['broadcastTransaction']>[0]
   | Parameters<TNear['broadcastTransaction']>[0]
-  | Parameters<Eth['broadcastTransaction']>[0]
-  | Parameters<Hteth['broadcastTransaction']>[0]
-  | Parameters<Flr['broadcastTransaction']>[0]
-  | Parameters<Tflr['broadcastTransaction']>[0]
-  | Parameters<Wemix['broadcastTransaction']>[0]
-  | Parameters<Twemix['broadcastTransaction']>[0]
-  | Parameters<Xdc['broadcastTransaction']>[0]
-  | Parameters<Txdc['broadcastTransaction']>[0]
-  | Parameters<Sgb['broadcastTransaction']>[0]
-  | Parameters<Tsgb['broadcastTransaction']>[0]
-  | Parameters<Oas['broadcastTransaction']>[0]
-  | Parameters<Toas['broadcastTransaction']>[0]
-  | Parameters<Coredao['broadcastTransaction']>[0]
-  | Parameters<Tcoredao['broadcastTransaction']>[0]
-  | Parameters<Polygon['broadcastTransaction']>[0]
-  | Parameters<Tpolygon['broadcastTransaction']>[0]
   | Parameters<Icp['broadcastTransaction']>[0]
   | Parameters<Ticp['broadcastTransaction']>[0]
 >;


### PR DESCRIPTION
Typecasting of coin instances before calling `createBroadcastableSweepTransaction` is no longer necessary as this has been refactored in the BaseCoin class. Additionally, type definitions for parameters are being derived from different coin instances is not needed.

- Remove typecasting of coin instances before calling createBroadcastableSweepTransaction.
- Eliminate the definition of parameter types for createBroadcastableSweepTransaction as all implementations use the same parameter type.
- Remove type definitions for broadcastTransaction for EVM coins, as none of the EVM coins implement this method.



Ticket: WIN-6102