### PR TITLE
feat: add fee rate input to recovery forms for utxo

### DIFF
--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -793,6 +793,7 @@ function Form() {
                 scan: Number(values.scan),
                 bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
                 ignoreAddressTypes: [],
+                feeRate: values.feeRate ? Number(values.feeRate) : undefined,
               });
               assert(
                 isRecoveryTransaction(recoverData),

--- a/src/containers/BuildUnsignedSweepCoin/LitecoinForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/LitecoinForm.tsx
@@ -12,6 +12,7 @@ const validationSchema = Yup.object({
   scan: Yup.number().required(),
   userKey: Yup.string().required(),
   userKeyId: Yup.string(),
+  feeRate: Yup.number().nullable().optional(),
 }).required();
 
 export type LitecoinFormProps = {
@@ -35,6 +36,7 @@ export function LitecoinForm({ onSubmit }: LitecoinFormProps) {
       scan: 20,
       userKey: '',
       userKeyId: '',
+      feeRate: null,
     },
     validationSchema,
   });
@@ -90,6 +92,14 @@ export function LitecoinForm({ onSubmit }: LitecoinFormProps) {
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="(optional) The fee rate in base units per byte to use for the recovery transaction."
+            Label="Fee Rate"
+            name="feeRate"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/DogecoinForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/DogecoinForm.tsx
@@ -17,6 +17,7 @@ const validationSchema = Yup.object({
   backupKey: Yup.string().required(),
   bitgoKey: Yup.string().required(),
   walletPassphrase: Yup.string().required(),
+  feeRate: Yup.number().nullable().optional(),
   recoveryDestination: Yup.string().required(),
   scan: Yup.number().required(),
 }).required();
@@ -42,6 +43,7 @@ export function DogecoinForm({ onSubmit }: DogecoinFormProps) {
       recoveryDestination: '',
       scan: 20,
       krsProvider: '',
+      feeRate: null,
     },
     validationSchema,
   });
@@ -97,6 +99,14 @@ export function DogecoinForm({ onSubmit }: DogecoinFormProps) {
             HelperText="The address your recovery transaction will send to."
             Label="Destination Address"
             name="recoveryDestination"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="(optional) The fee rate in base units per byte to use for the recovery transaction."
+            Label="Fee Rate"
+            name="feeRate"
             Width="fill"
           />
         </div>

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -993,6 +993,7 @@ function Form() {
                 scan: Number(values.scan),
                 bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
                 ignoreAddressTypes: [],
+                feeRate: values.feeRate ? Number(values.feeRate) : undefined,
               });
               assert(
                 isRecoveryTransaction(recoverData),


### PR DESCRIPTION
Add optional fee rate input field to Dogecoin and other utxo recovery forms, allowing users to specify custom fee rates for recovery transactions.

Ticket: BTC-2291