### PR TITLE
feat(wrw): added recovery support for near tokens

### DIFF
--- a/electron/coinFactory.ts
+++ b/electron/coinFactory.ts
@@ -23,6 +23,8 @@ const tokenParentCoins = {
   sip10Token: 'stx',
   tsip10Token: 'stx',
   txrpToken: 'xrp',
+  nep141Token: 'near',
+  tnep141Token: 'near',
 };
 
 const CoinFactory = () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -43,7 +43,7 @@ import { Ethw } from '@bitgo/sdk-coin-ethw';
 import { Etc, Tetc } from '@bitgo/sdk-coin-etc';
 import { Flr,Tflr } from '@bitgo/sdk-coin-flr'
 import { Ltc } from '@bitgo/sdk-coin-ltc';
-import { Near, TNear } from '@bitgo/sdk-coin-near';
+import { Near, TNear, Nep141Token } from '@bitgo/sdk-coin-near';
 import { Oas, Toas } from '@bitgo/sdk-coin-oas';
 import { Opeth, Topeth, OpethToken } from '@bitgo/sdk-coin-opeth';
 import { Osmo, Tosmo } from '@bitgo/sdk-coin-osmo';
@@ -231,6 +231,9 @@ HbarToken.createTokenConstructors().forEach(({ name, coinConstructor }) => {
   sdk.register(name, coinConstructor);
 });
 Sip10Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
+  sdk.register(name, coinConstructor);
+});
+Nep141Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
   sdk.register(name, coinConstructor);
 });
 

--- a/src/components/CryptocurrencyIcon/get-dynamic-icon.ts
+++ b/src/components/CryptocurrencyIcon/get-dynamic-icon.ts
@@ -15,8 +15,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/1up'));
     case '2give':
       return lazy(() => import('cryptocurrency-icons/react/2give'));
-    case 'aau':
-      return lazy(() => import('cryptocurrency-icons/react/aau'));
     case 'aave':
       return lazy(() => import('cryptocurrency-icons/react/aave'));
     case 'abt':
@@ -29,8 +27,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/act'));
     case 'actn':
       return lazy(() => import('cryptocurrency-icons/react/actn'));
-    case 'acx':
-      return lazy(() => import('cryptocurrency-icons/react/acx'));
     case 'acxt':
       return lazy(() => import('cryptocurrency-icons/react/acxt'));
     case 'ada':
@@ -39,8 +35,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/adai'));
     case 'add':
       return lazy(() => import('cryptocurrency-icons/react/add'));
-    case 'ads':
-      return lazy(() => import('cryptocurrency-icons/react/ads'));
     case 'adx':
       return lazy(() => import('cryptocurrency-icons/react/adx'));
     case 'ae':
@@ -55,40 +49,22 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/aethos'));
     case 'aeur':
       return lazy(() => import('cryptocurrency-icons/react/aeur'));
-    case 'aeusdc':
-      return lazy(() => import('cryptocurrency-icons/react/aeusdc'));
-    case 'aevo':
-      return lazy(() => import('cryptocurrency-icons/react/aevo'));
-    case 'afsui':
-      return lazy(() => import('cryptocurrency-icons/react/afsui'));
     case 'agi':
       return lazy(() => import('cryptocurrency-icons/react/agi'));
     case 'agix':
       return lazy(() => import('cryptocurrency-icons/react/agix'));
     case 'agrs':
       return lazy(() => import('cryptocurrency-icons/react/agrs'));
-    case 'agwd':
-      return lazy(() => import('cryptocurrency-icons/react/agwd'));
-    case 'ai16z':
-      return lazy(() => import('cryptocurrency-icons/react/ai16z'));
     case 'aion':
       return lazy(() => import('cryptocurrency-icons/react/aion'));
-    case 'aitech':
-      return lazy(() => import('cryptocurrency-icons/react/aitech'));
     case 'akj':
       return lazy(() => import('cryptocurrency-icons/react/akj'));
     case 'akro':
       return lazy(() => import('cryptocurrency-icons/react/akro'));
-    case 'alch':
-      return lazy(() => import('cryptocurrency-icons/react/alch'));
     case 'alcx':
       return lazy(() => import('cryptocurrency-icons/react/alcx'));
-    case 'aleo':
-      return lazy(() => import('cryptocurrency-icons/react/aleo'));
     case 'aleph':
       return lazy(() => import('cryptocurrency-icons/react/aleph'));
-    case 'alex':
-      return lazy(() => import('cryptocurrency-icons/react/alex'));
     case 'algo':
       return lazy(() => import('cryptocurrency-icons/react/algo'));
     case 'ali':
@@ -101,8 +77,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/alpha'));
     case 'alpine':
       return lazy(() => import('cryptocurrency-icons/react/alpine'));
-    case 'alt':
-      return lazy(() => import('cryptocurrency-icons/react/alt'));
     case 'altlayer':
       return lazy(() => import('cryptocurrency-icons/react/altlayer'));
     case 'amb':
@@ -125,14 +99,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ana'));
     case 'anc':
       return lazy(() => import('cryptocurrency-icons/react/anc'));
-    case 'anime':
-      return lazy(() => import('cryptocurrency-icons/react/anime'));
     case 'ankr':
       return lazy(() => import('cryptocurrency-icons/react/ankr'));
     case 'ant':
       return lazy(() => import('cryptocurrency-icons/react/ant'));
-    case 'antv2':
-      return lazy(() => import('cryptocurrency-icons/react/antv2'));
     case 'aoa':
       return lazy(() => import('cryptocurrency-icons/react/aoa'));
     case 'ape':
@@ -145,26 +115,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/apis'));
     case 'appc':
       return lazy(() => import('cryptocurrency-icons/react/appc'));
-    case 'apt':
-      return lazy(() => import('cryptocurrency-icons/react/apt'));
-    case 'aptpact':
-      return lazy(() => import('cryptocurrency-icons/react/aptpact'));
     case 'aqt':
       return lazy(() => import('cryptocurrency-icons/react/aqt'));
-    case 'aqua':
-      return lazy(() => import('cryptocurrency-icons/react/aqua'));
     case 'arb':
       return lazy(() => import('cryptocurrency-icons/react/arb'));
     case 'arbeth':
       return lazy(() => import('cryptocurrency-icons/react/arbeth'));
-    case 'arbethtbill':
-      return lazy(() => import('cryptocurrency-icons/react/arbethtbill'));
-    case 'arbethvchf':
-      return lazy(() => import('cryptocurrency-icons/react/arbethvchf'));
-    case 'arbethveur':
-      return lazy(() => import('cryptocurrency-icons/react/arbethveur'));
-    case 'arc':
-      return lazy(() => import('cryptocurrency-icons/react/arc'));
     case 'arct':
       return lazy(() => import('cryptocurrency-icons/react/arct'));
     case 'arcx':
@@ -189,8 +145,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ary'));
     case 'asd':
       return lazy(() => import('cryptocurrency-icons/react/asd'));
-    case 'asi':
-      return lazy(() => import('cryptocurrency-icons/react/asi'));
     case 'ast':
       return lazy(() => import('cryptocurrency-icons/react/ast'));
     case 'asto':
@@ -215,12 +169,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/audio'));
     case 'audr':
       return lazy(() => import('cryptocurrency-icons/react/audr'));
-    case 'audu':
-      return lazy(() => import('cryptocurrency-icons/react/audu'));
     case 'audx':
       return lazy(() => import('cryptocurrency-icons/react/audx'));
-    case 'aura':
-      return lazy(() => import('cryptocurrency-icons/react/aura'));
     case 'aury':
       return lazy(() => import('cryptocurrency-icons/react/aury'));
     case 'ausd':
@@ -237,14 +187,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ava'));
     case 'avax':
       return lazy(() => import('cryptocurrency-icons/react/avax'));
-    case 'avaxc':
-      return lazy(() => import('cryptocurrency-icons/react/avaxc'));
-    case 'avaxceurc':
-      return lazy(() => import('cryptocurrency-icons/react/avaxceurc'));
-    case 'avaxp':
-      return lazy(() => import('cryptocurrency-icons/react/avaxp'));
-    case 'avaxx':
-      return lazy(() => import('cryptocurrency-icons/react/avaxx'));
     case 'axl':
       return lazy(() => import('cryptocurrency-icons/react/axl'));
     case 'axlv2':
@@ -253,26 +195,18 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/axpr'));
     case 'axs':
       return lazy(() => import('cryptocurrency-icons/react/axs'));
-    case 'axsv2':
-      return lazy(() => import('cryptocurrency-icons/react/axsv2'));
     case 'aywa':
       return lazy(() => import('cryptocurrency-icons/react/aywa'));
     case 'bab':
       return lazy(() => import('cryptocurrency-icons/react/bab'));
     case 'babb':
       return lazy(() => import('cryptocurrency-icons/react/babb'));
-    case 'baby':
-      return lazy(() => import('cryptocurrency-icons/react/baby'));
-    case 'babydoge':
-      return lazy(() => import('cryptocurrency-icons/react/babydoge'));
     case 'badger':
       return lazy(() => import('cryptocurrency-icons/react/badger'));
     case 'bake':
       return lazy(() => import('cryptocurrency-icons/react/bake'));
     case 'bal':
       return lazy(() => import('cryptocurrency-icons/react/bal'));
-    case 'banca':
-      return lazy(() => import('cryptocurrency-icons/react/banca'));
     case 'band':
       return lazy(() => import('cryptocurrency-icons/react/band'));
     case 'bao':
@@ -327,16 +261,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/bepro'));
     case 'bera':
       return lazy(() => import('cryptocurrency-icons/react/bera'));
-    case 'berahoney':
-      return lazy(() => import('cryptocurrency-icons/react/berahoney'));
-    case 'berry':
-      return lazy(() => import('cryptocurrency-icons/react/berry'));
     case 'beta':
       return lazy(() => import('cryptocurrency-icons/react/beta'));
     case 'bgb':
       return lazy(() => import('cryptocurrency-icons/react/bgb'));
-    case 'bgt':
-      return lazy(() => import('cryptocurrency-icons/react/bgt'));
     case 'bico':
       return lazy(() => import('cryptocurrency-icons/react/bico'));
     case 'bid':
@@ -349,8 +277,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/bird'));
     case 'bit':
       return lazy(() => import('cryptocurrency-icons/react/bit'));
-    case 'bito':
-      return lazy(() => import('cryptocurrency-icons/react/bito'));
     case 'bix':
       return lazy(() => import('cryptocurrency-icons/react/bix'));
     case 'blcn':
@@ -391,8 +317,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/bond'));
     case 'bonk':
       return lazy(() => import('cryptocurrency-icons/react/bonk'));
-    case 'bonzo':
-      return lazy(() => import('cryptocurrency-icons/react/bonzo'));
     case 'booty':
       return lazy(() => import('cryptocurrency-icons/react/booty'));
     case 'borg':
@@ -419,8 +343,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/brz'));
     case 'bsc':
       return lazy(() => import('cryptocurrency-icons/react/bsc'));
-    case 'bscyfi':
-      return lazy(() => import('cryptocurrency-icons/react/bscyfi'));
     case 'bsd':
       return lazy(() => import('cryptocurrency-icons/react/bsd'));
     case 'bsgg':
@@ -461,8 +383,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/btu'));
     case 'btx':
       return lazy(() => import('cryptocurrency-icons/react/btx'));
-    case 'buidl':
-      return lazy(() => import('cryptocurrency-icons/react/buidl'));
     case 'bull':
       return lazy(() => import('cryptocurrency-icons/react/bull'));
     case 'burger':
@@ -477,8 +397,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/buy'));
     case 'bxx':
       return lazy(() => import('cryptocurrency-icons/react/bxx'));
-    case 'bxxv1':
-      return lazy(() => import('cryptocurrency-icons/react/bxxv1'));
     case 'bze':
       return lazy(() => import('cryptocurrency-icons/react/bze'));
     case 'bznt':
@@ -501,16 +419,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/call'));
     case 'carv':
       return lazy(() => import('cryptocurrency-icons/react/carv'));
-    case 'cat':
-      return lazy(() => import('cryptocurrency-icons/react/cat'));
     case 'cbat':
       return lazy(() => import('cryptocurrency-icons/react/cbat'));
     case 'cbc':
       return lazy(() => import('cryptocurrency-icons/react/cbc'));
-    case 'cbeth':
-      return lazy(() => import('cryptocurrency-icons/react/cbeth'));
-    case 'cbl':
-      return lazy(() => import('cryptocurrency-icons/react/cbl'));
     case 'cbrl':
       return lazy(() => import('cryptocurrency-icons/react/cbrl'));
     case 'cc':
@@ -533,16 +445,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/celr'));
     case 'cenz':
       return lazy(() => import('cryptocurrency-icons/react/cenz'));
-    case 'cet':
-      return lazy(() => import('cryptocurrency-icons/react/cet'));
-    case 'cetes':
-      return lazy(() => import('cryptocurrency-icons/react/cetes'));
     case 'ceth':
       return lazy(() => import('cryptocurrency-icons/react/ceth'));
-    case 'cetus':
-      return lazy(() => import('cryptocurrency-icons/react/cetus'));
-    case 'cfg':
-      return lazy(() => import('cryptocurrency-icons/react/cfg'));
     case 'cfx':
       return lazy(() => import('cryptocurrency-icons/react/cfx'));
     case 'cgld':
@@ -557,10 +461,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/chex'));
     case 'chfx':
       return lazy(() => import('cryptocurrency-icons/react/chfx'));
-    case 'chill':
-      return lazy(() => import('cryptocurrency-icons/react/chill'));
-    case 'chillguy':
-      return lazy(() => import('cryptocurrency-icons/react/chillguy'));
     case 'chips':
       return lazy(() => import('cryptocurrency-icons/react/chips'));
     case 'cho':
@@ -605,8 +505,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/cnd'));
     case 'cng':
       return lazy(() => import('cryptocurrency-icons/react/cng'));
-    case 'cnkt':
-      return lazy(() => import('cryptocurrency-icons/react/cnkt'));
     case 'cnx':
       return lazy(() => import('cryptocurrency-icons/react/cnx'));
     case 'cny':
@@ -629,8 +527,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/coqui'));
     case 'core':
       return lazy(() => import('cryptocurrency-icons/react/core'));
-    case 'coredao':
-      return lazy(() => import('cryptocurrency-icons/react/coredao'));
     case 'coreum':
       return lazy(() => import('cryptocurrency-icons/react/coreum'));
     case 'cos':
@@ -639,8 +535,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/coti'));
     case 'cover':
       return lazy(() => import('cryptocurrency-icons/react/cover'));
-    case 'cow':
-      return lazy(() => import('cryptocurrency-icons/react/cow'));
     case 'cpay':
       return lazy(() => import('cryptocurrency-icons/react/cpay'));
     case 'cplt':
@@ -649,8 +543,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/cpt'));
     case 'cqt':
       return lazy(() => import('cryptocurrency-icons/react/cqt'));
-    case 'cqx':
-      return lazy(() => import('cryptocurrency-icons/react/cqx'));
     case 'cra':
       return lazy(() => import('cryptocurrency-icons/react/cra'));
     case 'crdt':
@@ -667,8 +559,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/crep'));
     case 'cro':
       return lazy(() => import('cryptocurrency-icons/react/cro'));
-    case 'cronos':
-      return lazy(() => import('cryptocurrency-icons/react/cronos'));
     case 'crown':
       return lazy(() => import('cryptocurrency-icons/react/crown'));
     case 'crpt':
@@ -681,8 +571,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/crw'));
     case 'cs':
       return lazy(() => import('cryptocurrency-icons/react/cs'));
-    case 'cslv':
-      return lazy(() => import('cryptocurrency-icons/react/cslv'));
     case 'csp':
       return lazy(() => import('cryptocurrency-icons/react/csp'));
     case 'cspr':
@@ -691,8 +579,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ctk'));
     case 'ctr':
       return lazy(() => import('cryptocurrency-icons/react/ctr'));
-    case 'ctrl':
-      return lazy(() => import('cryptocurrency-icons/react/ctrl'));
     case 'ctsi':
       return lazy(() => import('cryptocurrency-icons/react/ctsi'));
     case 'ctx':
@@ -703,10 +589,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/cusd'));
     case 'cusdc':
       return lazy(() => import('cryptocurrency-icons/react/cusdc'));
-    case 'cusdo':
-      return lazy(() => import('cryptocurrency-icons/react/cusdo'));
-    case 'cvault':
-      return lazy(() => import('cryptocurrency-icons/react/cvault'));
     case 'cvc':
       return lazy(() => import('cryptocurrency-icons/react/cvc'));
     case 'cvx':
@@ -733,16 +615,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/dat'));
     case 'data':
       return lazy(() => import('cryptocurrency-icons/react/data'));
-    case 'dataecon':
-      return lazy(() => import('cryptocurrency-icons/react/dataecon'));
     case 'datav2':
       return lazy(() => import('cryptocurrency-icons/react/datav2'));
     case 'dawn':
       return lazy(() => import('cryptocurrency-icons/react/dawn'));
     case 'dbc':
       return lazy(() => import('cryptocurrency-icons/react/dbc'));
-    case 'dbusd':
-      return lazy(() => import('cryptocurrency-icons/react/dbusd'));
     case 'dcn':
       return lazy(() => import('cryptocurrency-icons/react/dcn'));
     case 'dcr':
@@ -765,10 +643,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/dent'));
     case 'dep':
       return lazy(() => import('cryptocurrency-icons/react/dep'));
-    case 'deuro':
-      return lazy(() => import('cryptocurrency-icons/react/deuro'));
-    case 'deusd':
-      return lazy(() => import('cryptocurrency-icons/react/deusd'));
     case 'dew':
       return lazy(() => import('cryptocurrency-icons/react/dew'));
     case 'dexa':
@@ -777,8 +651,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/dexe'));
     case 'dfd':
       return lazy(() => import('cryptocurrency-icons/react/dfd'));
-    case 'dfdvsol':
-      return lazy(() => import('cryptocurrency-icons/react/dfdvsol'));
     case 'dfi':
       return lazy(() => import('cryptocurrency-icons/react/dfi'));
     case 'dfx':
@@ -811,30 +683,18 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/dock'));
     case 'dodo':
       return lazy(() => import('cryptocurrency-icons/react/dodo'));
-    case 'dog':
-      return lazy(() => import('cryptocurrency-icons/react/dog'));
     case 'doge':
       return lazy(() => import('cryptocurrency-icons/react/doge'));
-    case 'dolo':
-      return lazy(() => import('cryptocurrency-icons/react/dolo'));
     case 'domi':
       return lazy(() => import('cryptocurrency-icons/react/domi'));
-    case 'dood':
-      return lazy(() => import('cryptocurrency-icons/react/dood'));
     case 'dot':
       return lazy(() => import('cryptocurrency-icons/react/dot'));
-    case 'dovu':
-      return lazy(() => import('cryptocurrency-icons/react/dovu'));
     case 'dpi':
       return lazy(() => import('cryptocurrency-icons/react/dpi'));
-    case 'dragonx':
-      return lazy(() => import('cryptocurrency-icons/react/dragonx'));
     case 'dram':
       return lazy(() => import('cryptocurrency-icons/react/dram'));
     case 'drgn':
       return lazy(() => import('cryptocurrency-icons/react/drgn'));
-    case 'drift':
-      return lazy(() => import('cryptocurrency-icons/react/drift'));
     case 'drop':
       return lazy(() => import('cryptocurrency-icons/react/drop'));
     case 'drpu':
@@ -873,16 +733,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/easy'));
     case 'ebst':
       return lazy(() => import('cryptocurrency-icons/react/ebst'));
-    case 'ebtcq':
-      return lazy(() => import('cryptocurrency-icons/react/ebtcq'));
     case 'eca':
       return lazy(() => import('cryptocurrency-icons/react/eca'));
-    case 'ecash':
-      return lazy(() => import('cryptocurrency-icons/react/ecash'));
     case 'echt':
       return lazy(() => import('cryptocurrency-icons/react/echt'));
-    case 'eco':
-      return lazy(() => import('cryptocurrency-icons/react/eco'));
     case 'ecox':
       return lazy(() => import('cryptocurrency-icons/react/ecox'));
     case 'eden':
@@ -935,8 +789,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/emc'));
     case 'emc2':
       return lazy(() => import('cryptocurrency-icons/react/emc2'));
-    case 'emdx':
-      return lazy(() => import('cryptocurrency-icons/react/emdx'));
     case 'emx':
       return lazy(() => import('cryptocurrency-icons/react/emx'));
     case 'ena':
@@ -945,8 +797,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/eng'));
     case 'enj':
       return lazy(() => import('cryptocurrency-icons/react/enj'));
-    case 'enron':
-      return lazy(() => import('cryptocurrency-icons/react/enron'));
     case 'ens':
       return lazy(() => import('cryptocurrency-icons/react/ens'));
     case 'entrp':
@@ -973,8 +823,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/erc'));
     case 'erd':
       return lazy(() => import('cryptocurrency-icons/react/erd'));
-    case 'es':
-      return lazy(() => import('cryptocurrency-icons/react/es'));
     case 'ese':
       return lazy(() => import('cryptocurrency-icons/react/ese'));
     case 'eta':
@@ -983,38 +831,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/etc'));
     case 'eth':
       return lazy(() => import('cryptocurrency-icons/react/eth'));
-    case 'ethausd':
-      return lazy(() => import('cryptocurrency-icons/react/ethausd'));
-    case 'ethblock':
-      return lazy(() => import('cryptocurrency-icons/react/ethblock'));
-    case 'ethchex':
-      return lazy(() => import('cryptocurrency-icons/react/ethchex'));
     case 'ethfi':
       return lazy(() => import('cryptocurrency-icons/react/ethfi'));
-    case 'ethfuel':
-      return lazy(() => import('cryptocurrency-icons/react/ethfuel'));
-    case 'ethfuelv1':
-      return lazy(() => import('cryptocurrency-icons/react/ethfuelv1'));
-    case 'ethmon':
-      return lazy(() => import('cryptocurrency-icons/react/ethmon'));
     case 'ethos':
       return lazy(() => import('cryptocurrency-icons/react/ethos'));
-    case 'ethpoe':
-      return lazy(() => import('cryptocurrency-icons/react/ethpoe'));
-    case 'ethpyr':
-      return lazy(() => import('cryptocurrency-icons/react/ethpyr'));
-    case 'ethsc':
-      return lazy(() => import('cryptocurrency-icons/react/ethsc'));
-    case 'ethsky':
-      return lazy(() => import('cryptocurrency-icons/react/ethsky'));
-    case 'ethstq':
-      return lazy(() => import('cryptocurrency-icons/react/ethstq'));
     case 'ethton':
       return lazy(() => import('cryptocurrency-icons/react/ethton'));
-    case 'ethuco':
-      return lazy(() => import('cryptocurrency-icons/react/ethuco'));
-    case 'ethusds':
-      return lazy(() => import('cryptocurrency-icons/react/ethusds'));
     case 'etn':
       return lazy(() => import('cryptocurrency-icons/react/etn'));
     case 'etp':
@@ -1025,8 +847,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/eul'));
     case 'eur':
       return lazy(() => import('cryptocurrency-icons/react/eur'));
-    case 'eurau':
-      return lazy(() => import('cryptocurrency-icons/react/eurau'));
     case 'eurc':
       return lazy(() => import('cryptocurrency-icons/react/eurc'));
     case 'eurcv':
@@ -1037,14 +857,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/eure'));
     case 'eurl':
       return lazy(() => import('cryptocurrency-icons/react/eurl'));
-    case 'eurob':
-      return lazy(() => import('cryptocurrency-icons/react/eurob'));
     case 'euroc':
       return lazy(() => import('cryptocurrency-icons/react/euroc'));
     case 'euroe':
       return lazy(() => import('cryptocurrency-icons/react/euroe'));
-    case 'europ':
-      return lazy(() => import('cryptocurrency-icons/react/europ'));
     case 'eurr':
       return lazy(() => import('cryptocurrency-icons/react/eurr'));
     case 'eurs':
@@ -1073,16 +889,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/exmo'));
     case 'exp':
       return lazy(() => import('cryptocurrency-icons/react/exp'));
-    case 'exrd':
-      return lazy(() => import('cryptocurrency-icons/react/exrd'));
-    case 'ez':
-      return lazy(() => import('cryptocurrency-icons/react/ez'));
     case 'fair':
       return lazy(() => import('cryptocurrency-icons/react/fair'));
     case 'farm':
       return lazy(() => import('cryptocurrency-icons/react/farm'));
-    case 'fartcoin':
-      return lazy(() => import('cryptocurrency-icons/react/fartcoin'));
     case 'fcd':
       return lazy(() => import('cryptocurrency-icons/react/fcd'));
     case 'fct':
@@ -1097,14 +907,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/fet'));
     case 'fet1':
       return lazy(() => import('cryptocurrency-icons/react/fet1'));
-    case 'fetchai':
-      return lazy(() => import('cryptocurrency-icons/react/fetchai'));
     case 'ff':
       return lazy(() => import('cryptocurrency-icons/react/ff'));
     case 'ff1':
       return lazy(() => import('cryptocurrency-icons/react/ff1'));
-    case 'fft':
-      return lazy(() => import('cryptocurrency-icons/react/fft'));
     case 'fida':
       return lazy(() => import('cryptocurrency-icons/react/fida'));
     case 'fil':
@@ -1115,8 +921,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/firo'));
     case 'fis':
       return lazy(() => import('cryptocurrency-icons/react/fis'));
-    case 'fixed':
-      return lazy(() => import('cryptocurrency-icons/react/fixed'));
     case 'fjc':
       return lazy(() => import('cryptocurrency-icons/react/fjc'));
     case 'fldc':
@@ -1125,22 +929,16 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/flo'));
     case 'floki':
       return lazy(() => import('cryptocurrency-icons/react/floki'));
-    case 'flr':
-      return lazy(() => import('cryptocurrency-icons/react/flr'));
     case 'flux':
       return lazy(() => import('cryptocurrency-icons/react/flux'));
     case 'fly':
       return lazy(() => import('cryptocurrency-icons/react/fly'));
-    case 'flz':
-      return lazy(() => import('cryptocurrency-icons/react/flz'));
     case 'fmf':
       return lazy(() => import('cryptocurrency-icons/react/fmf'));
     case 'fold':
       return lazy(() => import('cryptocurrency-icons/react/fold'));
     case 'for':
       return lazy(() => import('cryptocurrency-icons/react/for'));
-    case 'form':
-      return lazy(() => import('cryptocurrency-icons/react/form'));
     case 'fort':
       return lazy(() => import('cryptocurrency-icons/react/fort'));
     case 'forth':
@@ -1155,28 +953,20 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ftc'));
     case 'ftm':
       return lazy(() => import('cryptocurrency-icons/react/ftm'));
-    case 'ftn':
-      return lazy(() => import('cryptocurrency-icons/react/ftn'));
     case 'ftt':
       return lazy(() => import('cryptocurrency-icons/react/ftt'));
-    case 'fud':
-      return lazy(() => import('cryptocurrency-icons/react/fud'));
     case 'fuel':
       return lazy(() => import('cryptocurrency-icons/react/fuel'));
     case 'fun':
       return lazy(() => import('cryptocurrency-icons/react/fun'));
     case 'fwb':
       return lazy(() => import('cryptocurrency-icons/react/fwb'));
-    case 'fx':
-      return lazy(() => import('cryptocurrency-icons/react/fx'));
     case 'fxrt':
       return lazy(() => import('cryptocurrency-icons/react/fxrt'));
     case 'fxs':
       return lazy(() => import('cryptocurrency-icons/react/fxs'));
     case 'g':
       return lazy(() => import('cryptocurrency-icons/react/g'));
-    case 'gaia':
-      return lazy(() => import('cryptocurrency-icons/react/gaia'));
     case 'gal':
       return lazy(() => import('cryptocurrency-icons/react/gal'));
     case 'gala':
@@ -1221,22 +1011,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/gfi'));
     case 'gft':
       return lazy(() => import('cryptocurrency-icons/react/gft'));
-    case 'ghcn':
-      return lazy(() => import('cryptocurrency-icons/react/ghcn'));
-    case 'ghdo':
-      return lazy(() => import('cryptocurrency-icons/react/ghdo'));
-    case 'gho':
-      return lazy(() => import('cryptocurrency-icons/react/gho'));
     case 'ghst':
       return lazy(() => import('cryptocurrency-icons/react/ghst'));
     case 'ghub':
       return lazy(() => import('cryptocurrency-icons/react/ghub'));
-    case 'giga':
-      return lazy(() => import('cryptocurrency-icons/react/giga'));
     case 'gigdrop':
       return lazy(() => import('cryptocurrency-icons/react/gigdrop'));
-    case 'gilts':
-      return lazy(() => import('cryptocurrency-icons/react/gilts'));
     case 'gin':
       return lazy(() => import('cryptocurrency-icons/react/gin'));
     case 'gldx':
@@ -1257,62 +1037,36 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/gno'));
     case 'gnt':
       return lazy(() => import('cryptocurrency-icons/react/gnt'));
-    case 'go':
-      return lazy(() => import('cryptocurrency-icons/react/go'));
-    case 'goat':
-      return lazy(() => import('cryptocurrency-icons/react/goat'));
-    case 'god':
-      return lazy(() => import('cryptocurrency-icons/react/god'));
     case 'gods':
       return lazy(() => import('cryptocurrency-icons/react/gods'));
     case 'gog':
       return lazy(() => import('cryptocurrency-icons/react/gog'));
     case 'gohm':
       return lazy(() => import('cryptocurrency-icons/react/gohm'));
-    case 'gohome':
-      return lazy(() => import('cryptocurrency-icons/react/gohome'));
     case 'gold':
       return lazy(() => import('cryptocurrency-icons/react/gold'));
-    case 'gomining':
-      return lazy(() => import('cryptocurrency-icons/react/gomining'));
     case 'got':
       return lazy(() => import('cryptocurrency-icons/react/got'));
-    case 'gousd':
-      return lazy(() => import('cryptocurrency-icons/react/gousd'));
-    case 'grass':
-      return lazy(() => import('cryptocurrency-icons/react/grass'));
     case 'grc':
       return lazy(() => import('cryptocurrency-icons/react/grc'));
     case 'grin':
       return lazy(() => import('cryptocurrency-icons/react/grin'));
-    case 'grph':
-      return lazy(() => import('cryptocurrency-icons/react/grph'));
     case 'grs':
       return lazy(() => import('cryptocurrency-icons/react/grs'));
     case 'grt':
       return lazy(() => import('cryptocurrency-icons/react/grt'));
-    case 'gs':
-      return lazy(() => import('cryptocurrency-icons/react/gs'));
     case 'gsc':
       return lazy(() => import('cryptocurrency-icons/react/gsc'));
     case 'gt':
       return lazy(() => import('cryptocurrency-icons/react/gt'));
     case 'gtc':
       return lazy(() => import('cryptocurrency-icons/react/gtc'));
-    case 'gteth':
-      return lazy(() => import('cryptocurrency-icons/react/gteth'));
     case 'gto':
       return lazy(() => import('cryptocurrency-icons/react/gto'));
-    case 'guild':
-      return lazy(() => import('cryptocurrency-icons/react/guild'));
-    case 'gunz':
-      return lazy(() => import('cryptocurrency-icons/react/gunz'));
     case 'gup':
       return lazy(() => import('cryptocurrency-icons/react/gup'));
     case 'gusd':
       return lazy(() => import('cryptocurrency-icons/react/gusd'));
-    case 'gusdt':
-      return lazy(() => import('cryptocurrency-icons/react/gusdt'));
     case 'gvt':
       return lazy(() => import('cryptocurrency-icons/react/gvt'));
     case 'gxc':
@@ -1323,20 +1077,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/gyen'));
     case 'gzr':
       return lazy(() => import('cryptocurrency-icons/react/gzr'));
-    case 'h':
-      return lazy(() => import('cryptocurrency-icons/react/h'));
-    case 'h2o':
-      return lazy(() => import('cryptocurrency-icons/react/h2o'));
-    case 'hard':
-      return lazy(() => import('cryptocurrency-icons/react/hard'));
     case 'hash':
       return lazy(() => import('cryptocurrency-icons/react/hash'));
     case 'hbar':
       return lazy(() => import('cryptocurrency-icons/react/hbar'));
-    case 'hbarkarate':
-      return lazy(() => import('cryptocurrency-icons/react/hbarkarate'));
-    case 'hbb':
-      return lazy(() => import('cryptocurrency-icons/react/hbb'));
     case 'hbg':
       return lazy(() => import('cryptocurrency-icons/react/hbg'));
     case 'hcn':
@@ -1345,8 +1089,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/hdo'));
     case 'hedg':
       return lazy(() => import('cryptocurrency-icons/react/hedg'));
-    case 'hegic':
-      return lazy(() => import('cryptocurrency-icons/react/hegic'));
     case 'heth':
       return lazy(() => import('cryptocurrency-icons/react/heth'));
     case 'hex':
@@ -1387,14 +1129,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/hqt'));
     case 'hrxo':
       return lazy(() => import('cryptocurrency-icons/react/hrxo'));
-    case 'hsol':
-      return lazy(() => import('cryptocurrency-icons/react/hsol'));
     case 'hsr':
       return lazy(() => import('cryptocurrency-icons/react/hsr'));
     case 'hst':
       return lazy(() => import('cryptocurrency-icons/react/hst'));
-    case 'hsuite':
-      return lazy(() => import('cryptocurrency-icons/react/hsuite'));
     case 'ht':
       return lazy(() => import('cryptocurrency-icons/react/ht'));
     case 'html':
@@ -1419,14 +1157,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/hyperlane'));
     case 'i8':
       return lazy(() => import('cryptocurrency-icons/react/i8'));
-    case 'ibera':
-      return lazy(() => import('cryptocurrency-icons/react/ibera'));
-    case 'ibtc':
-      return lazy(() => import('cryptocurrency-icons/react/ibtc'));
     case 'icn':
       return lazy(() => import('cryptocurrency-icons/react/icn'));
-    case 'icnt':
-      return lazy(() => import('cryptocurrency-icons/react/icnt'));
     case 'icp':
       return lazy(() => import('cryptocurrency-icons/react/icp'));
     case 'icx':
@@ -1443,12 +1175,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ignis'));
     case 'ilk':
       return lazy(() => import('cryptocurrency-icons/react/ilk'));
-    case 'ilv':
-      return lazy(() => import('cryptocurrency-icons/react/ilv'));
     case 'imx':
       return lazy(() => import('cryptocurrency-icons/react/imx'));
-    case 'imxv2':
-      return lazy(() => import('cryptocurrency-icons/react/imxv2'));
     case 'incx':
       return lazy(() => import('cryptocurrency-icons/react/incx'));
     case 'ind':
@@ -1459,8 +1187,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/indi'));
     case 'inf':
       return lazy(() => import('cryptocurrency-icons/react/inf'));
-    case 'initia':
-      return lazy(() => import('cryptocurrency-icons/react/initia'));
     case 'inj':
       return lazy(() => import('cryptocurrency-icons/react/inj'));
     case 'injective':
@@ -1473,8 +1199,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ins'));
     case 'inst':
       return lazy(() => import('cryptocurrency-icons/react/inst'));
-    case 'insur':
-      return lazy(() => import('cryptocurrency-icons/react/insur'));
     case 'inx':
       return lazy(() => import('cryptocurrency-icons/react/inx'));
     case 'io':
@@ -1489,8 +1213,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/iotx'));
     case 'iq':
       return lazy(() => import('cryptocurrency-icons/react/iq'));
-    case 'iris':
-      return lazy(() => import('cryptocurrency-icons/react/iris'));
     case 'isei':
       return lazy(() => import('cryptocurrency-icons/react/isei'));
     case 'isf':
@@ -1503,8 +1225,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/itc'));
     case 'ivy':
       return lazy(() => import('cryptocurrency-icons/react/ivy'));
-    case 'jam':
-      return lazy(() => import('cryptocurrency-icons/react/jam'));
     case 'jasmy':
       return lazy(() => import('cryptocurrency-icons/react/jasmy'));
     case 'jbc':
@@ -1523,8 +1243,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/jito'));
     case 'jitosol':
       return lazy(() => import('cryptocurrency-icons/react/jitosol'));
-    case 'jlp':
-      return lazy(() => import('cryptocurrency-icons/react/jlp'));
     case 'jnt':
       return lazy(() => import('cryptocurrency-icons/react/jnt'));
     case 'joe':
@@ -1533,12 +1251,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/jpy'));
     case 'jpyx':
       return lazy(() => import('cryptocurrency-icons/react/jpyx'));
-    case 'jto':
-      return lazy(() => import('cryptocurrency-icons/react/jto'));
     case 'jup':
       return lazy(() => import('cryptocurrency-icons/react/jup'));
-    case 'kal':
-      return lazy(() => import('cryptocurrency-icons/react/kal'));
     case 'kalk':
       return lazy(() => import('cryptocurrency-icons/react/kalk'));
     case 'kambria':
@@ -1549,8 +1263,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/kas'));
     case 'kat':
       return lazy(() => import('cryptocurrency-icons/react/kat'));
-    case 'kava':
-      return lazy(() => import('cryptocurrency-icons/react/kava'));
     case 'kcs':
       return lazy(() => import('cryptocurrency-icons/react/kcs'));
     case 'keep':
@@ -1573,8 +1285,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/klown'));
     case 'kmd':
       return lazy(() => import('cryptocurrency-icons/react/kmd'));
-    case 'kmno':
-      return lazy(() => import('cryptocurrency-icons/react/kmno'));
     case 'knc':
       return lazy(() => import('cryptocurrency-icons/react/knc'));
     case 'knc2':
@@ -1599,12 +1309,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/l3'));
     case 'l3usd':
       return lazy(() => import('cryptocurrency-icons/react/l3usd'));
-    case 'la':
-      return lazy(() => import('cryptocurrency-icons/react/la'));
     case 'lagrange':
       return lazy(() => import('cryptocurrency-icons/react/lagrange'));
-    case 'launchcoin':
-      return lazy(() => import('cryptocurrency-icons/react/launchcoin'));
     case 'layer':
       return lazy(() => import('cryptocurrency-icons/react/layer'));
     case 'lazio':
@@ -1623,10 +1329,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/leo'));
     case 'lever':
       return lazy(() => import('cryptocurrency-icons/react/lever'));
-    case 'lf':
-      return lazy(() => import('cryptocurrency-icons/react/lf'));
-    case 'lgct':
-      return lazy(() => import('cryptocurrency-icons/react/lgct'));
     case 'lgo':
       return lazy(() => import('cryptocurrency-icons/react/lgo'));
     case 'lif3':
@@ -1653,8 +1355,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/looks'));
     case 'loom':
       return lazy(() => import('cryptocurrency-icons/react/loom'));
-    case 'loom1':
-      return lazy(() => import('cryptocurrency-icons/react/loom1'));
     case 'lovely':
       return lazy(() => import('cryptocurrency-icons/react/lovely'));
     case 'lp':
@@ -1663,8 +1363,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/lpt'));
     case 'lrc':
       return lazy(() => import('cryptocurrency-icons/react/lrc'));
-    case 'lrcv2':
-      return lazy(() => import('cryptocurrency-icons/react/lrcv2'));
     case 'lsk':
       return lazy(() => import('cryptocurrency-icons/react/lsk'));
     case 'ltc':
@@ -1689,8 +1387,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/mask'));
     case 'matic':
       return lazy(() => import('cryptocurrency-icons/react/matic'));
-    case 'matrix':
-      return lazy(() => import('cryptocurrency-icons/react/matrix'));
     case 'mav':
       return lazy(() => import('cryptocurrency-icons/react/mav'));
     case 'max':
@@ -1725,16 +1421,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/mdt'));
     case 'mdx':
       return lazy(() => import('cryptocurrency-icons/react/mdx'));
-    case 'me':
-      return lazy(() => import('cryptocurrency-icons/react/me'));
     case 'med':
       return lazy(() => import('cryptocurrency-icons/react/med'));
     case 'medx':
       return lazy(() => import('cryptocurrency-icons/react/medx'));
     case 'meetone':
       return lazy(() => import('cryptocurrency-icons/react/meetone'));
-    case 'melania':
-      return lazy(() => import('cryptocurrency-icons/react/melania'));
     case 'meme':
       return lazy(() => import('cryptocurrency-icons/react/meme'));
     case 'meow':
@@ -1791,18 +1483,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/mof'));
     case 'mog':
       return lazy(() => import('cryptocurrency-icons/react/mog'));
-    case 'mon':
-      return lazy(() => import('cryptocurrency-icons/react/mon'));
     case 'mona':
       return lazy(() => import('cryptocurrency-icons/react/mona'));
-    case 'moodeng':
-      return lazy(() => import('cryptocurrency-icons/react/moodeng'));
-    case 'morpho':
-      return lazy(() => import('cryptocurrency-icons/react/morpho'));
     case 'mother':
       return lazy(() => import('cryptocurrency-icons/react/mother'));
-    case 'move':
-      return lazy(() => import('cryptocurrency-icons/react/move'));
     case 'moveusd':
       return lazy(() => import('cryptocurrency-icons/react/moveusd'));
     case 'mpay':
@@ -1831,26 +1515,16 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/musd'));
     case 'music':
       return lazy(() => import('cryptocurrency-icons/react/music'));
-    case 'muskit':
-      return lazy(() => import('cryptocurrency-icons/react/muskit'));
-    case 'mv':
-      return lazy(() => import('cryptocurrency-icons/react/mv'));
     case 'mvi':
       return lazy(() => import('cryptocurrency-icons/react/mvi'));
     case 'mvl':
       return lazy(() => import('cryptocurrency-icons/react/mvl'));
-    case 'mwt':
-      return lazy(() => import('cryptocurrency-icons/react/mwt'));
-    case 'mx':
-      return lazy(() => import('cryptocurrency-icons/react/mx'));
     case 'myrc':
       return lazy(() => import('cryptocurrency-icons/react/myrc'));
     case 'myth':
       return lazy(() => import('cryptocurrency-icons/react/myth'));
     case 'mzc':
       return lazy(() => import('cryptocurrency-icons/react/mzc'));
-    case 'naka':
-      return lazy(() => import('cryptocurrency-icons/react/naka'));
     case 'nano':
       return lazy(() => import('cryptocurrency-icons/react/nano'));
     case 'nas':
@@ -1859,10 +1533,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/natix'));
     case 'nav':
       return lazy(() => import('cryptocurrency-icons/react/nav'));
-    case 'navx':
-      return lazy(() => import('cryptocurrency-icons/react/navx'));
-    case 'nc':
-      return lazy(() => import('cryptocurrency-icons/react/nc'));
     case 'ncash':
       return lazy(() => import('cryptocurrency-icons/react/ncash'));
     case 'nct':
@@ -1875,8 +1545,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/near'));
     case 'nebl':
       return lazy(() => import('cryptocurrency-icons/react/nebl'));
-    case 'neiro':
-      return lazy(() => import('cryptocurrency-icons/react/neiro'));
     case 'neo':
       return lazy(() => import('cryptocurrency-icons/react/neo'));
     case 'neos':
@@ -1885,8 +1553,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/neu'));
     case 'nexo':
       return lazy(() => import('cryptocurrency-icons/react/nexo'));
-    case 'nft':
-      return lazy(() => import('cryptocurrency-icons/react/nft'));
     case 'nftfi':
       return lazy(() => import('cryptocurrency-icons/react/nftfi'));
     case 'nftx':
@@ -1911,22 +1577,16 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/nmr'));
     case 'nnn':
       return lazy(() => import('cryptocurrency-icons/react/nnn'));
-    case 'nos':
-      return lazy(() => import('cryptocurrency-icons/react/nos'));
     case 'nosana':
       return lazy(() => import('cryptocurrency-icons/react/nosana'));
     case 'note':
       return lazy(() => import('cryptocurrency-icons/react/note'));
-    case 'npc':
-      return lazy(() => import('cryptocurrency-icons/react/npc'));
     case 'npt':
       return lazy(() => import('cryptocurrency-icons/react/npt'));
     case 'npxs':
       return lazy(() => import('cryptocurrency-icons/react/npxs'));
     case 'ns2d':
       return lazy(() => import('cryptocurrency-icons/react/ns2d'));
-    case 'ns2drp':
-      return lazy(() => import('cryptocurrency-icons/react/ns2drp'));
     case 'ntbc':
       return lazy(() => import('cryptocurrency-icons/react/ntbc'));
     case 'nu':
@@ -1935,30 +1595,20 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/nuls'));
     case 'nvm':
       return lazy(() => import('cryptocurrency-icons/react/nvm'));
-    case 'nxm':
-      return lazy(() => import('cryptocurrency-icons/react/nxm'));
-    case 'nxpc':
-      return lazy(() => import('cryptocurrency-icons/react/nxpc'));
     case 'nxs':
       return lazy(() => import('cryptocurrency-icons/react/nxs'));
     case 'nxt':
       return lazy(() => import('cryptocurrency-icons/react/nxt'));
-    case 'nyan':
-      return lazy(() => import('cryptocurrency-icons/react/nyan'));
     case 'nym':
       return lazy(() => import('cryptocurrency-icons/react/nym'));
     case 'nzdx':
       return lazy(() => import('cryptocurrency-icons/react/nzdx'));
-    case 'oas':
-      return lazy(() => import('cryptocurrency-icons/react/oas'));
     case 'oax':
       return lazy(() => import('cryptocurrency-icons/react/oax'));
     case 'ocean':
       return lazy(() => import('cryptocurrency-icons/react/ocean'));
     case 'oceanv2':
       return lazy(() => import('cryptocurrency-icons/react/oceanv2'));
-    case 'ocn':
-      return lazy(() => import('cryptocurrency-icons/react/ocn'));
     case 'ogn':
       return lazy(() => import('cryptocurrency-icons/react/ogn'));
     case 'ohm':
@@ -1991,8 +1641,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ont'));
     case 'ooki':
       return lazy(() => import('cryptocurrency-icons/react/ooki'));
-    case 'oort':
-      return lazy(() => import('cryptocurrency-icons/react/oort'));
     case 'oot':
       return lazy(() => import('cryptocurrency-icons/react/oot'));
     case 'op':
@@ -2003,8 +1651,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/openlayer'));
     case 'opeth':
       return lazy(() => import('cryptocurrency-icons/react/opeth'));
-    case 'opt':
-      return lazy(() => import('cryptocurrency-icons/react/opt'));
     case 'orai':
       return lazy(() => import('cryptocurrency-icons/react/orai'));
     case 'orbs':
@@ -2027,16 +1673,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/oxt'));
     case 'oxy':
       return lazy(() => import('cryptocurrency-icons/react/oxy'));
-    case 'pack':
-      return lazy(() => import('cryptocurrency-icons/react/pack'));
     case 'pact':
       return lazy(() => import('cryptocurrency-icons/react/pact'));
     case 'par':
       return lazy(() => import('cryptocurrency-icons/react/par'));
     case 'part':
       return lazy(() => import('cryptocurrency-icons/react/part'));
-    case 'parti':
-      return lazy(() => import('cryptocurrency-icons/react/parti'));
     case 'pasc':
       return lazy(() => import('cryptocurrency-icons/react/pasc'));
     case 'pasl':
@@ -2065,14 +1707,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/peaq'));
     case 'peg':
       return lazy(() => import('cryptocurrency-icons/react/peg'));
-    case 'pengu':
-      return lazy(() => import('cryptocurrency-icons/react/pengu'));
     case 'penky':
       return lazy(() => import('cryptocurrency-icons/react/penky'));
     case 'pepe':
       return lazy(() => import('cryptocurrency-icons/react/pepe'));
-    case 'perc':
-      return lazy(() => import('cryptocurrency-icons/react/perc'));
     case 'perl':
       return lazy(() => import('cryptocurrency-icons/react/perl'));
     case 'perp':
@@ -2109,8 +1747,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/plnx'));
     case 'plr':
       return lazy(() => import('cryptocurrency-icons/react/plr'));
-    case 'plume':
-      return lazy(() => import('cryptocurrency-icons/react/plume'));
     case 'plx':
       return lazy(() => import('cryptocurrency-icons/react/plx'));
     case 'pma':
@@ -2119,8 +1755,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/png'));
     case 'pnt':
       return lazy(() => import('cryptocurrency-icons/react/pnt'));
-    case 'pnut':
-      return lazy(() => import('cryptocurrency-icons/react/pnut'));
     case 'poa':
       return lazy(() => import('cryptocurrency-icons/react/poa'));
     case 'poe':
@@ -2135,10 +1769,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/poly'));
     case 'polygon':
       return lazy(() => import('cryptocurrency-icons/react/polygon'));
-    case 'polygonbid':
-      return lazy(() => import('cryptocurrency-icons/react/polygonbid'));
-    case 'polyx':
-      return lazy(() => import('cryptocurrency-icons/react/polyx'));
     case 'pond':
       return lazy(() => import('cryptocurrency-icons/react/pond'));
     case 'popcat':
@@ -2155,12 +1785,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ppp'));
     case 'ppt':
       return lazy(() => import('cryptocurrency-icons/react/ppt'));
-    case 'prdx':
-      return lazy(() => import('cryptocurrency-icons/react/prdx'));
     case 'pre':
       return lazy(() => import('cryptocurrency-icons/react/pre'));
-    case 'prints':
-      return lazy(() => import('cryptocurrency-icons/react/prints'));
     case 'prl':
       return lazy(() => import('cryptocurrency-icons/react/prl'));
     case 'pro':
@@ -2173,8 +1799,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/psg'));
     case 'pstake':
       return lazy(() => import('cryptocurrency-icons/react/pstake'));
-    case 'pump':
-      return lazy(() => import('cryptocurrency-icons/react/pump'));
     case 'pundix':
       return lazy(() => import('cryptocurrency-icons/react/pundix'));
     case 'pungo':
@@ -2263,8 +1887,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/rdn'));
     case 'rdnt':
       return lazy(() => import('cryptocurrency-icons/react/rdnt'));
-    case 'rdo':
-      return lazy(() => import('cryptocurrency-icons/react/rdo'));
     case 'reb':
       return lazy(() => import('cryptocurrency-icons/react/reb'));
     case 'rebl':
@@ -2313,14 +1935,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/rlusd'));
     case 'rly':
       return lazy(() => import('cryptocurrency-icons/react/rly'));
-    case 'rmg':
-      return lazy(() => import('cryptocurrency-icons/react/rmg'));
     case 'rn':
       return lazy(() => import('cryptocurrency-icons/react/rn'));
     case 'rndr':
       return lazy(() => import('cryptocurrency-icons/react/rndr'));
-    case 'rock':
-      return lazy(() => import('cryptocurrency-icons/react/rock'));
     case 'ron':
       return lazy(() => import('cryptocurrency-icons/react/ron'));
     case 'ronc':
@@ -2331,8 +1949,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/rook'));
     case 'rose':
       return lazy(() => import('cryptocurrency-icons/react/rose'));
-    case 'route':
-      return lazy(() => import('cryptocurrency-icons/react/route'));
     case 'rpk':
       return lazy(() => import('cryptocurrency-icons/react/rpk'));
     case 'rpl':
@@ -2343,8 +1959,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/rsr'));
     case 'rsweth':
       return lazy(() => import('cryptocurrency-icons/react/rsweth'));
-    case 'rtbl':
-      return lazy(() => import('cryptocurrency-icons/react/rtbl'));
     case 'rub':
       return lazy(() => import('cryptocurrency-icons/react/rub'));
     case 'rubx':
@@ -2357,8 +1971,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/rvn'));
     case 'ryo':
       return lazy(() => import('cryptocurrency-icons/react/ryo'));
-    case 'ryt':
-      return lazy(() => import('cryptocurrency-icons/react/ryt'));
     case 'safe':
       return lazy(() => import('cryptocurrency-icons/react/safe'));
     case 'safemoon':
@@ -2375,24 +1987,16 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sand'));
     case 'santos':
       return lazy(() => import('cryptocurrency-icons/react/santos'));
-    case 'saros':
-      return lazy(() => import('cryptocurrency-icons/react/saros'));
     case 'sashimi':
       return lazy(() => import('cryptocurrency-icons/react/sashimi'));
-    case 'sauce':
-      return lazy(() => import('cryptocurrency-icons/react/sauce'));
     case 'savax':
       return lazy(() => import('cryptocurrency-icons/react/savax'));
-    case 'sb':
-      return lazy(() => import('cryptocurrency-icons/react/sb'));
     case 'sbc':
       return lazy(() => import('cryptocurrency-icons/react/sbc'));
     case 'sbd':
       return lazy(() => import('cryptocurrency-icons/react/sbd'));
     case 'sberbank':
       return lazy(() => import('cryptocurrency-icons/react/sberbank'));
-    case 'sbtc':
-      return lazy(() => import('cryptocurrency-icons/react/sbtc'));
     case 'sc':
       return lazy(() => import('cryptocurrency-icons/react/sc'));
     case 'sca':
@@ -2403,8 +2007,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sd'));
     case 'sei':
       return lazy(() => import('cryptocurrency-icons/react/sei'));
-    case 'send':
-      return lazy(() => import('cryptocurrency-icons/react/send'));
     case 'ser':
       return lazy(() => import('cryptocurrency-icons/react/ser'));
     case 'seth2':
@@ -2415,8 +2017,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sfp'));
     case 'sga':
       return lazy(() => import('cryptocurrency-icons/react/sga'));
-    case 'sgb':
-      return lazy(() => import('cryptocurrency-icons/react/sgb'));
     case 'sgdx':
       return lazy(() => import('cryptocurrency-icons/react/sgdx'));
     case 'sgr':
@@ -2435,8 +2035,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/shopx'));
     case 'shr':
       return lazy(() => import('cryptocurrency-icons/react/shr'));
-    case 'shrap':
-      return lazy(() => import('cryptocurrency-icons/react/shrap'));
     case 'sib':
       return lazy(() => import('cryptocurrency-icons/react/sib'));
     case 'sih':
@@ -2471,8 +2069,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/slr'));
     case 'sls':
       return lazy(() => import('cryptocurrency-icons/react/sls'));
-    case 'slt':
-      return lazy(() => import('cryptocurrency-icons/react/slt'));
     case 'slvx':
       return lazy(() => import('cryptocurrency-icons/react/slvx'));
     case 'smart':
@@ -2497,34 +2093,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sohm'));
     case 'sol':
       return lazy(() => import('cryptocurrency-icons/react/sol'));
-    case 'solanacorn':
-      return lazy(() => import('cryptocurrency-icons/react/solanacorn'));
-    case 'solausd':
-      return lazy(() => import('cryptocurrency-icons/react/solausd'));
-    case 'solbenji':
-      return lazy(() => import('cryptocurrency-icons/react/solbenji'));
-    case 'soleurcv':
-      return lazy(() => import('cryptocurrency-icons/react/soleurcv'));
     case 'solink':
       return lazy(() => import('cryptocurrency-icons/react/solink'));
-    case 'sollayer':
-      return lazy(() => import('cryptocurrency-icons/react/sollayer'));
-    case 'solo':
-      return lazy(() => import('cryptocurrency-icons/react/solo'));
-    case 'soltbill':
-      return lazy(() => import('cryptocurrency-icons/react/soltbill'));
-    case 'solusdg':
-      return lazy(() => import('cryptocurrency-icons/react/solusdg'));
-    case 'solv':
-      return lazy(() => import('cryptocurrency-icons/react/solv'));
-    case 'solvchf':
-      return lazy(() => import('cryptocurrency-icons/react/solvchf'));
     case 'solve':
       return lazy(() => import('cryptocurrency-icons/react/solve'));
-    case 'solveur':
-      return lazy(() => import('cryptocurrency-icons/react/solveur'));
-    case 'soneium':
-      return lazy(() => import('cryptocurrency-icons/react/soneium'));
     case 'sos':
       return lazy(() => import('cryptocurrency-icons/react/sos'));
     case 'spacehbit':
@@ -2539,10 +2111,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sphtx'));
     case 'spo':
       return lazy(() => import('cryptocurrency-icons/react/spo'));
-    case 'sprw':
-      return lazy(() => import('cryptocurrency-icons/react/sprw'));
-    case 'spx':
-      return lazy(() => import('cryptocurrency-icons/react/spx'));
     case 'sqd':
       return lazy(() => import('cryptocurrency-icons/react/sqd'));
     case 'squig':
@@ -2553,8 +2121,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/srn'));
     case 'srnt':
       return lazy(() => import('cryptocurrency-icons/react/srnt'));
-    case 'ssol':
-      return lazy(() => import('cryptocurrency-icons/react/ssol'));
     case 'ssv':
       return lazy(() => import('cryptocurrency-icons/react/ssv'));
     case 'stak':
@@ -2565,14 +2131,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/stbu'));
     case 'stc':
       return lazy(() => import('cryptocurrency-icons/react/stc'));
-    case 'stcv2':
-      return lazy(() => import('cryptocurrency-icons/react/stcv2'));
     case 'steem':
       return lazy(() => import('cryptocurrency-icons/react/steem'));
     case 'stg':
       return lazy(() => import('cryptocurrency-icons/react/stg'));
-    case 'stik':
-      return lazy(() => import('cryptocurrency-icons/react/stik'));
     case 'stkaave':
       return lazy(() => import('cryptocurrency-icons/react/stkaave'));
     case 'stmx':
@@ -2595,14 +2157,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/strk'));
     case 'strong':
       return lazy(() => import('cryptocurrency-icons/react/strong'));
-    case 'ststx':
-      return lazy(() => import('cryptocurrency-icons/react/ststx'));
-    case 'stt':
-      return lazy(() => import('cryptocurrency-icons/react/stt'));
     case 'stx':
       return lazy(() => import('cryptocurrency-icons/react/stx'));
-    case 'stzen':
-      return lazy(() => import('cryptocurrency-icons/react/stzen'));
     case 'sub':
       return lazy(() => import('cryptocurrency-icons/react/sub'));
     case 'sui':
@@ -2615,20 +2171,14 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sun'));
     case 'super':
       return lazy(() => import('cryptocurrency-icons/react/super'));
-    case 'superbonds':
-      return lazy(() => import('cryptocurrency-icons/react/superbonds'));
     case 'susd':
       return lazy(() => import('cryptocurrency-icons/react/susd'));
     case 'susde':
       return lazy(() => import('cryptocurrency-icons/react/susde'));
-    case 'susdh':
-      return lazy(() => import('cryptocurrency-icons/react/susdh'));
     case 'sushi':
       return lazy(() => import('cryptocurrency-icons/react/sushi'));
     case 'swap':
       return lazy(() => import('cryptocurrency-icons/react/swap'));
-    case 'swarms':
-      return lazy(() => import('cryptocurrency-icons/react/swarms'));
     case 'sweth':
       return lazy(() => import('cryptocurrency-icons/react/sweth'));
     case 'swise':
@@ -2637,60 +2187,34 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/sxp'));
     case 'syn':
       return lazy(() => import('cryptocurrency-icons/react/syn'));
-    case 'syrup':
-      return lazy(() => import('cryptocurrency-icons/react/syrup'));
     case 'sys':
       return lazy(() => import('cryptocurrency-icons/react/sys'));
     case 't':
       return lazy(() => import('cryptocurrency-icons/react/t'));
     case 'taas':
       return lazy(() => import('cryptocurrency-icons/react/taas'));
-    case 'tai':
-      return lazy(() => import('cryptocurrency-icons/react/tai'));
-    case 'tao':
-      return lazy(() => import('cryptocurrency-icons/react/tao'));
     case 'tau':
       return lazy(() => import('cryptocurrency-icons/react/tau'));
     case 'taud':
       return lazy(() => import('cryptocurrency-icons/react/taud'));
     case 'tbtc':
       return lazy(() => import('cryptocurrency-icons/react/tbtc'));
-    case 'tbtc1':
-      return lazy(() => import('cryptocurrency-icons/react/tbtc1'));
     case 'tbx':
       return lazy(() => import('cryptocurrency-icons/react/tbx'));
     case 'tcad':
       return lazy(() => import('cryptocurrency-icons/react/tcad'));
     case 'tco':
       return lazy(() => import('cryptocurrency-icons/react/tco'));
-    case 'tcs':
-      return lazy(() => import('cryptocurrency-icons/react/tcs'));
-    case 'tdai':
-      return lazy(() => import('cryptocurrency-icons/react/tdai'));
     case 'tel':
       return lazy(() => import('cryptocurrency-icons/react/tel'));
-    case 'telos':
-      return lazy(() => import('cryptocurrency-icons/react/telos'));
     case 'ten':
       return lazy(() => import('cryptocurrency-icons/react/ten'));
     case 'tenx':
       return lazy(() => import('cryptocurrency-icons/react/tenx'));
-    case 'terc':
-      return lazy(() => import('cryptocurrency-icons/react/terc'));
-    case 'terc18dp':
-      return lazy(() => import('cryptocurrency-icons/react/terc18dp'));
-    case 'terc2dp':
-      return lazy(() => import('cryptocurrency-icons/react/terc2dp'));
-    case 'terc6dp':
-      return lazy(() => import('cryptocurrency-icons/react/terc6dp'));
     case 'term':
       return lazy(() => import('cryptocurrency-icons/react/term'));
     case 'tern':
       return lazy(() => import('cryptocurrency-icons/react/tern'));
-    case 'tesouro':
-      return lazy(() => import('cryptocurrency-icons/react/tesouro'));
-    case 'testcopm':
-      return lazy(() => import('cryptocurrency-icons/react/testcopm'));
     case 'tgbp':
       return lazy(() => import('cryptocurrency-icons/react/tgbp'));
     case 'tgch':
@@ -2699,8 +2223,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/theta'));
     case 'thkd':
       return lazy(() => import('cryptocurrency-icons/react/thkd'));
-    case 'thor':
-      return lazy(() => import('cryptocurrency-icons/react/thor'));
     case 'threshold':
       return lazy(() => import('cryptocurrency-icons/react/threshold'));
     case 'thunder':
@@ -2709,10 +2231,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/tia'));
     case 'tico':
       return lazy(() => import('cryptocurrency-icons/react/tico'));
-    case 'ticov2':
-      return lazy(() => import('cryptocurrency-icons/react/ticov2'));
-    case 'times':
-      return lazy(() => import('cryptocurrency-icons/react/times'));
     case 'tiox':
       return lazy(() => import('cryptocurrency-icons/react/tiox'));
     case 'tix':
@@ -2733,16 +2251,12 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/tlab'));
     case 'tlm':
       return lazy(() => import('cryptocurrency-icons/react/tlm'));
-    case 'tlos':
-      return lazy(() => import('cryptocurrency-icons/react/tlos'));
     case 'tm':
       return lazy(() => import('cryptocurrency-icons/react/tm'));
     case 'tnb':
       return lazy(() => import('cryptocurrency-icons/react/tnb'));
     case 'tnc':
       return lazy(() => import('cryptocurrency-icons/react/tnc'));
-    case 'tnsr':
-      return lazy(() => import('cryptocurrency-icons/react/tnsr'));
     case 'tnt':
       return lazy(() => import('cryptocurrency-icons/react/tnt'));
     case 'tok':
@@ -2755,8 +2269,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/tomoe'));
     case 'ton':
       return lazy(() => import('cryptocurrency-icons/react/ton'));
-    case 'towns':
-      return lazy(() => import('cryptocurrency-icons/react/towns'));
     case 'tpay':
       return lazy(() => import('cryptocurrency-icons/react/tpay'));
     case 'trac':
@@ -2777,8 +2289,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/trittium'));
     case 'trl':
       return lazy(() => import('cryptocurrency-icons/react/trl'));
-    case 'trn':
-      return lazy(() => import('cryptocurrency-icons/react/trn'));
     case 'troy':
       return lazy(() => import('cryptocurrency-icons/react/troy'));
     case 'trst':
@@ -2789,38 +2299,22 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/tru'));
     case 'truf':
       return lazy(() => import('cryptocurrency-icons/react/truf'));
-    case 'trufv2':
-      return lazy(() => import('cryptocurrency-icons/react/trufv2'));
-    case 'trump':
-      return lazy(() => import('cryptocurrency-icons/react/trump'));
     case 'trx':
       return lazy(() => import('cryptocurrency-icons/react/trx'));
-    case 'trxs':
-      return lazy(() => import('cryptocurrency-icons/react/trxs'));
     case 'tryb':
       return lazy(() => import('cryptocurrency-icons/react/tryb'));
     case 'tryx':
       return lazy(() => import('cryptocurrency-icons/react/tryx'));
-    case 'tsbtc':
-      return lazy(() => import('cryptocurrency-icons/react/tsbtc'));
     case 'tst':
       return lazy(() => import('cryptocurrency-icons/react/tst'));
-    case 'tsteth':
-      return lazy(() => import('cryptocurrency-icons/react/tsteth'));
     case 'tt':
       return lazy(() => import('cryptocurrency-icons/react/tt'));
-    case 'turbo':
-      return lazy(() => import('cryptocurrency-icons/react/turbo'));
     case 'tusd':
       return lazy(() => import('cryptocurrency-icons/react/tusd'));
     case 'twt':
       return lazy(() => import('cryptocurrency-icons/react/twt'));
     case 'txl':
       return lazy(() => import('cryptocurrency-icons/react/txl'));
-    case 'txrplxsgd':
-      return lazy(() => import('cryptocurrency-icons/react/txrplxsgd'));
-    case 'txsgd':
-      return lazy(() => import('cryptocurrency-icons/react/txsgd'));
     case 'txusd':
       return lazy(() => import('cryptocurrency-icons/react/txusd'));
     case 'tzc':
@@ -2835,36 +2329,24 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/uco'));
     case 'uft':
       return lazy(() => import('cryptocurrency-icons/react/uft'));
-    case 'uhu':
-      return lazy(() => import('cryptocurrency-icons/react/uhu'));
     case 'ukg':
       return lazy(() => import('cryptocurrency-icons/react/ukg'));
-    case 'ultra':
-      return lazy(() => import('cryptocurrency-icons/react/ultra'));
     case 'uma':
       return lazy(() => import('cryptocurrency-icons/react/uma'));
     case 'umee':
       return lazy(() => import('cryptocurrency-icons/react/umee'));
-    case 'umint':
-      return lazy(() => import('cryptocurrency-icons/react/umint'));
-    case 'una':
-      return lazy(() => import('cryptocurrency-icons/react/una'));
     case 'unb':
       return lazy(() => import('cryptocurrency-icons/react/unb'));
     case 'unfi':
       return lazy(() => import('cryptocurrency-icons/react/unfi'));
     case 'uni':
       return lazy(() => import('cryptocurrency-icons/react/uni'));
-    case 'unio':
-      return lazy(() => import('cryptocurrency-icons/react/unio'));
     case 'unity':
       return lazy(() => import('cryptocurrency-icons/react/unity'));
     case 'up':
       return lazy(() => import('cryptocurrency-icons/react/up'));
     case 'upbtc':
       return lazy(() => import('cryptocurrency-icons/react/upbtc'));
-    case 'upc':
-      return lazy(() => import('cryptocurrency-icons/react/upc'));
     case 'upp':
       return lazy(() => import('cryptocurrency-icons/react/upp'));
     case 'upt':
@@ -2877,56 +2359,32 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/urhd'));
     case 'usd':
       return lazy(() => import('cryptocurrency-icons/react/usd'));
-    case 'usd0':
-      return lazy(() => import('cryptocurrency-icons/react/usd0'));
-    case 'usd1':
-      return lazy(() => import('cryptocurrency-icons/react/usd1'));
     case 'usdc':
       return lazy(() => import('cryptocurrency-icons/react/usdc'));
-    case 'usdcv':
-      return lazy(() => import('cryptocurrency-icons/react/usdcv'));
     case 'usdcv2':
       return lazy(() => import('cryptocurrency-icons/react/usdcv2'));
     case 'usdd':
       return lazy(() => import('cryptocurrency-icons/react/usdd'));
     case 'usde':
       return lazy(() => import('cryptocurrency-icons/react/usde'));
-    case 'usdf':
-      return lazy(() => import('cryptocurrency-icons/react/usdf'));
-    case 'usdg':
-      return lazy(() => import('cryptocurrency-icons/react/usdg'));
     case 'usdglo':
       return lazy(() => import('cryptocurrency-icons/react/usdglo'));
-    case 'usdh':
-      return lazy(() => import('cryptocurrency-icons/react/usdh'));
     case 'usdp':
       return lazy(() => import('cryptocurrency-icons/react/usdp'));
-    case 'usds':
-      return lazy(() => import('cryptocurrency-icons/react/usds'));
     case 'usdt':
       return lazy(() => import('cryptocurrency-icons/react/usdt'));
-    case 'usdtb':
-      return lazy(() => import('cryptocurrency-icons/react/usdtb'));
     case 'usdx':
       return lazy(() => import('cryptocurrency-icons/react/usdx'));
     case 'usdy':
       return lazy(() => import('cryptocurrency-icons/react/usdy'));
-    case 'useless':
-      return lazy(() => import('cryptocurrency-icons/react/useless'));
     case 'usg':
       return lazy(() => import('cryptocurrency-icons/react/usg'));
-    case 'uson':
-      return lazy(() => import('cryptocurrency-icons/react/uson'));
     case 'uspx':
       return lazy(() => import('cryptocurrency-icons/react/uspx'));
     case 'ust':
       return lazy(() => import('cryptocurrency-icons/react/ust'));
     case 'ustb':
       return lazy(() => import('cryptocurrency-icons/react/ustb'));
-    case 'ustry':
-      return lazy(() => import('cryptocurrency-icons/react/ustry'));
-    case 'usual':
-      return lazy(() => import('cryptocurrency-icons/react/usual'));
     case 'usx':
       return lazy(() => import('cryptocurrency-icons/react/usx'));
     case 'usyc':
@@ -2937,16 +2395,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/utk1'));
     case 'valor':
       return lazy(() => import('cryptocurrency-icons/react/valor'));
-    case 'vana':
-      return lazy(() => import('cryptocurrency-icons/react/vana'));
     case 'vanry':
       return lazy(() => import('cryptocurrency-icons/react/vanry'));
-    case 'vaulta':
-      return lazy(() => import('cryptocurrency-icons/react/vaulta'));
-    case 'vbill':
-      return lazy(() => import('cryptocurrency-icons/react/vbill'));
-    case 'vcad':
-      return lazy(() => import('cryptocurrency-icons/react/vcad'));
     case 'vcnt':
       return lazy(() => import('cryptocurrency-icons/react/vcnt'));
     case 'vcore':
@@ -2963,10 +2413,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/veri'));
     case 'vet':
       return lazy(() => import('cryptocurrency-icons/react/vet'));
-    case 'vetvtho':
-      return lazy(() => import('cryptocurrency-icons/react/vetvtho'));
-    case 'vgbp':
-      return lazy(() => import('cryptocurrency-icons/react/vgbp'));
     case 'vgx':
       return lazy(() => import('cryptocurrency-icons/react/vgx'));
     case 'via':
@@ -2977,12 +2423,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/vibe'));
     case 'vic':
       return lazy(() => import('cryptocurrency-icons/react/vic'));
-    case 'vice':
-      return lazy(() => import('cryptocurrency-icons/react/vice'));
     case 'vidt':
       return lazy(() => import('cryptocurrency-icons/react/vidt'));
-    case 'virtual':
-      return lazy(() => import('cryptocurrency-icons/react/virtual'));
     case 'virtuese':
       return lazy(() => import('cryptocurrency-icons/react/virtuese'));
     case 'visr':
@@ -3005,12 +2447,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/vrgx'));
     case 'vrsc':
       return lazy(() => import('cryptocurrency-icons/react/vrsc'));
-    case 'vrtx':
-      return lazy(() => import('cryptocurrency-icons/react/vrtx'));
     case 'vsp':
       return lazy(() => import('cryptocurrency-icons/react/vsp'));
-    case 'vsui':
-      return lazy(() => import('cryptocurrency-icons/react/vsui'));
     case 'vtc':
       return lazy(() => import('cryptocurrency-icons/react/vtc'));
     case 'vtho':
@@ -3025,8 +2463,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/wadztoken'));
     case 'wafl':
       return lazy(() => import('cryptocurrency-icons/react/wafl'));
-    case 'wal':
-      return lazy(() => import('cryptocurrency-icons/react/wal'));
     case 'wan':
       return lazy(() => import('cryptocurrency-icons/react/wan'));
     case 'waves':
@@ -3037,14 +2473,10 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/waxp'));
     case 'wbnb':
       return lazy(() => import('cryptocurrency-icons/react/wbnb'));
-    case 'wbt':
-      return lazy(() => import('cryptocurrency-icons/react/wbt'));
     case 'wbtc':
       return lazy(() => import('cryptocurrency-icons/react/wbtc'));
     case 'wcfg':
       return lazy(() => import('cryptocurrency-icons/react/wcfg'));
-    case 'wct':
-      return lazy(() => import('cryptocurrency-icons/react/wct'));
     case 'wdoge':
       return lazy(() => import('cryptocurrency-icons/react/wdoge'));
     case 'wec':
@@ -3053,24 +2485,16 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/wecan'));
     case 'weeth':
       return lazy(() => import('cryptocurrency-icons/react/weeth'));
-    case 'welsh':
-      return lazy(() => import('cryptocurrency-icons/react/welsh'));
-    case 'wemix':
-      return lazy(() => import('cryptocurrency-icons/react/wemix'));
     case 'wet':
       return lazy(() => import('cryptocurrency-icons/react/wet'));
     case 'weth':
       return lazy(() => import('cryptocurrency-icons/react/weth'));
     case 'wflow':
       return lazy(() => import('cryptocurrency-icons/react/wflow'));
-    case 'wgbera':
-      return lazy(() => import('cryptocurrency-icons/react/wgbera'));
     case 'wgr':
       return lazy(() => import('cryptocurrency-icons/react/wgr'));
     case 'whale':
       return lazy(() => import('cryptocurrency-icons/react/whale'));
-    case 'white':
-      return lazy(() => import('cryptocurrency-icons/react/white'));
     case 'wht':
       return lazy(() => import('cryptocurrency-icons/react/wht'));
     case 'wicc':
@@ -3089,8 +2513,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/witness'));
     case 'wld':
       return lazy(() => import('cryptocurrency-icons/react/wld'));
-    case 'wlfi':
-      return lazy(() => import('cryptocurrency-icons/react/wlfi'));
     case 'wluna':
       return lazy(() => import('cryptocurrency-icons/react/wluna'));
     case 'wlxt':
@@ -3099,10 +2521,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/wnxm'));
     case 'woo':
       return lazy(() => import('cryptocurrency-icons/react/woo'));
-    case 'world':
-      return lazy(() => import('cryptocurrency-icons/react/world'));
-    case 'would':
-      return lazy(() => import('cryptocurrency-icons/react/would'));
     case 'wpr':
       return lazy(() => import('cryptocurrency-icons/react/wpr'));
     case 'wpx':
@@ -3115,26 +2533,18 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/wsohm'));
     case 'wsteth':
       return lazy(() => import('cryptocurrency-icons/react/wsteth'));
-    case 'wtao':
-      return lazy(() => import('cryptocurrency-icons/react/wtao'));
     case 'wtc':
       return lazy(() => import('cryptocurrency-icons/react/wtc'));
-    case 'wtgxx':
-      return lazy(() => import('cryptocurrency-icons/react/wtgxx'));
     case 'wtk':
       return lazy(() => import('cryptocurrency-icons/react/wtk'));
     case 'wusdc':
       return lazy(() => import('cryptocurrency-icons/react/wusdc'));
-    case 'wusdm':
-      return lazy(() => import('cryptocurrency-icons/react/wusdm'));
     case 'wxrp':
       return lazy(() => import('cryptocurrency-icons/react/wxrp'));
     case 'wxt':
       return lazy(() => import('cryptocurrency-icons/react/wxt'));
     case 'x':
       return lazy(() => import('cryptocurrency-icons/react/x'));
-    case 'xai':
-      return lazy(() => import('cryptocurrency-icons/react/xai'));
     case 'xas':
       return lazy(() => import('cryptocurrency-icons/react/xas'));
     case 'xaud':
@@ -3145,8 +2555,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/xava'));
     case 'xbc':
       return lazy(() => import('cryptocurrency-icons/react/xbc'));
-    case 'xbgold':
-      return lazy(() => import('cryptocurrency-icons/react/xbgold'));
     case 'xbp':
       return lazy(() => import('cryptocurrency-icons/react/xbp'));
     case 'xby':
@@ -3157,8 +2565,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/xchng'));
     case 'xcp':
       return lazy(() => import('cryptocurrency-icons/react/xcp'));
-    case 'xdc':
-      return lazy(() => import('cryptocurrency-icons/react/xdc'));
     case 'xdn':
       return lazy(() => import('cryptocurrency-icons/react/xdn'));
     case 'xec':
@@ -3189,26 +2595,14 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/xpm'));
     case 'xpr':
       return lazy(() => import('cryptocurrency-icons/react/xpr'));
-    case 'xreth':
-      return lazy(() => import('cryptocurrency-icons/react/xreth'));
     case 'xrl':
       return lazy(() => import('cryptocurrency-icons/react/xrl'));
     case 'xrp':
       return lazy(() => import('cryptocurrency-icons/react/xrp'));
-    case 'xrplvchf':
-      return lazy(() => import('cryptocurrency-icons/react/xrplvchf'));
-    case 'xrplveur':
-      return lazy(() => import('cryptocurrency-icons/react/xrplveur'));
-    case 'xrptbill':
-      return lazy(() => import('cryptocurrency-icons/react/xrptbill'));
-    case 'xrpxsgd':
-      return lazy(() => import('cryptocurrency-icons/react/xrpxsgd'));
     case 'xsg':
       return lazy(() => import('cryptocurrency-icons/react/xsg'));
     case 'xsgd':
       return lazy(() => import('cryptocurrency-icons/react/xsgd'));
-    case 'xsgdv2':
-      return lazy(() => import('cryptocurrency-icons/react/xsgdv2'));
     case 'xsushi':
       return lazy(() => import('cryptocurrency-icons/react/xsushi'));
     case 'xterio':
@@ -3227,8 +2621,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/xvg'));
     case 'xvs':
       return lazy(() => import('cryptocurrency-icons/react/xvs'));
-    case 'xy':
-      return lazy(() => import('cryptocurrency-icons/react/xy'));
     case 'xzc':
       return lazy(() => import('cryptocurrency-icons/react/xzc'));
     case 'xzk':
@@ -3251,12 +2643,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/ysey'));
     case 'zarx':
       return lazy(() => import('cryptocurrency-icons/react/zarx'));
-    case 'zbcn':
-      return lazy(() => import('cryptocurrency-icons/react/zbcn'));
     case 'zbu':
       return lazy(() => import('cryptocurrency-icons/react/zbu'));
-    case 'zbuv2':
-      return lazy(() => import('cryptocurrency-icons/react/zbuv2'));
     case 'zcl':
       return lazy(() => import('cryptocurrency-icons/react/zcl'));
     case 'zco':
@@ -3267,8 +2655,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/zel'));
     case 'zen':
       return lazy(() => import('cryptocurrency-icons/react/zen'));
-    case 'zerebro':
-      return lazy(() => import('cryptocurrency-icons/react/zerebro'));
     case 'zest':
       return lazy(() => import('cryptocurrency-icons/react/zest'));
     case 'zeta':
@@ -3277,8 +2663,6 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('cryptocurrency-icons/react/zetachain'));
     case 'zetaevm':
       return lazy(() => import('cryptocurrency-icons/react/zetaevm'));
-    case 'zeus':
-      return lazy(() => import('cryptocurrency-icons/react/zeus'));
     case 'zil':
       return lazy(() => import('cryptocurrency-icons/react/zil'));
     case 'zilla':

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -1643,9 +1643,12 @@ function Form() {
       );
     case 'near':
     case 'tnear':
+    case 'nep141Token':
+    case 'tnep141Token':
       return (
         <NearForm
   key={coin}
+  isToken={coin === 'nep141Token' || coin === 'tnep141Token'}
   onSubmit={async (values, { setSubmitting }) => {
     setAlert(undefined);
     setSubmitting(true);
@@ -1653,14 +1656,20 @@ function Form() {
       // Set the BitGo environment for the selected coin
       await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
 
+      let parentCoin: string | undefined;
+      if (coin === 'nep141Token' || coin === 'tnep141Token') {
+        parentCoin = tokenParentCoins[coin];
+      }
+
       // Fetch chain-specific data
-      const chainData = await window.queries.getChain(coin);
+      const chainData = parentCoin ? parentCoin : await window.queries.getChain(coin);
+      const callerCoin = parentCoin ? parentCoin : coin;
 
       // Recover data for the unsigned sweep
-      const recoverData = await window.commands.recover(coin, {
+      const recoverData = await window.commands.recover(callerCoin, {
           ...values,
-          userKey:(values.userKey ?? '').replace(/\s+/g, ''),
-          backupKey:(values.backupKey ?? '').replace(/\s+/g, ''),
+          userKey: (values.userKey ?? '').replace(/\s+/g, ''),
+          backupKey: (values.backupKey ?? '').replace(/\s+/g, ''),
           bitgoKey: values.bitgoKey, // Include the BitGo key
           recoveryDestination: values.recoveryDestination, // Include the recovery destination
           ignoreAddressTypes: [], // Update keys from IDs

--- a/src/containers/NonBitGoRecoveryCoin/NearForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NearForm.tsx
@@ -1,13 +1,21 @@
 import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
 import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
-import { Button, FormikTextarea, FormikTextfield } from '~/components';
+import {
+  Button,
+  FormikPasswordfield,
+  FormikSelectfield,
+  FormikTextarea,
+  FormikTextfield,
+} from '~/components';
 
 type NearFormValues = {
-  bitgoKey: string;
   backupKey: string;
-  userKey: string;
+  bitgoKey: string;
+  krsProvider: string;
   recoveryDestination: string;
+  userKey: string;
+  walletPassphrase: string;
   tokenContractAddress?: string;  // optional based on isToken
 }
 
@@ -21,49 +29,100 @@ export type NearFormProps = {
 
 export function NearForm({ onSubmit, isToken }: NearFormProps) {
   const schemaFields: Record<keyof NearFormValues, Yup.AnySchema> = {
+    backupKey: Yup.string().required('Backup Key is required'),
     bitgoKey: Yup.string().required('BitGo Key is required'),
+    krsProvider: Yup.string()
+      .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
+      .label('Key Recovery Service'),
     recoveryDestination: Yup.string().required('Recovery Destination is required'),
-    userKey: Yup.string(),
-    backupKey: Yup.string(),
+    userKey: Yup.string().required('User Key is required'),
+    walletPassphrase: Yup.string().required('WalletPassphrase is required'),
     tokenContractAddress: isToken
       ? Yup.string().required('Token contract address is required')
       : Yup.string().notRequired(),
   };
 
   const validationSchema = Yup.object(schemaFields);
+
   const initialValues: NearFormValues = {
+    backupKey: '',
     bitgoKey: '',
+    krsProvider: '',
     recoveryDestination: '',
     userKey: '',
-    backupKey: '',
+    walletPassphrase: '',
     ...(isToken ? { tokenContractAddress: '' } : {}),
   };
 
   const formik = useFormik<NearFormValues>({
+    onSubmit,
     initialValues,
     validationSchema,
-    onSubmit,
   });
+
+  const backupKeyHelperText =
+    formik.values.krsProvider === ''
+      ? 'Your encrypted backup key, as found on your BitGo recovery keycard.'
+      : 'The backup public key for the wallet, as found on your BitGo recovery keycard.';
 
   return (
     <FormikProvider value={formik}>
       <Form>
         <h4 className="tw-text-body tw-font-semibold tw-border-b-0.5 tw-border-solid tw-border-gray-700 tw-mb-4">
-          Self Custody Cold Wallets
+          Self-managed hot wallet details
         </h4>
+        <div className="tw-mb-4">
+          <FormikSelectfield
+            HelperText="The Key Recovery Service that you chose to manage your backup key. If you have the encrypted backup key, you may leave this blank."
+            Label="Key Recovery Service"
+            name="krsProvider"
+            Width="fill"
+          >
+            <option value="">None</option>
+            <option value="keyternal">Keyternal</option>
+            <option value="bitgoKRSv2">BitGo KRS</option>
+            <option value="dai">Coincover</option>
+          </FormikSelectfield>
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText="Your encrypted user key, as found on your recovery KeyCard."
+            Label="Box A Value"
+            name="userKey"
+            rows={4}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText={backupKeyHelperText}
+            Label="Box B Value"
+            name="backupKey"
+            rows={4}
+            Width="fill"
+          />
+        </div>
         <div className="tw-mb-4">
           <FormikTextarea
             HelperText="The BitGo public key for the wallet, as found on your recovery KeyCard."
-            Label="BitGo Key"
+            Label="Box C Value"
             name="bitgoKey"
-            rows={1}
+            rows={2}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikPasswordfield
+            HelperText="The passphrase of the wallet."
+            Label="Wallet Passphrase"
+            name="walletPassphrase"
             Width="fill"
           />
         </div>
         <div className="tw-mb-4">
           <FormikTextfield
             HelperText="The address your recovery transaction will send to."
-            Label="Recovery Destination"
+            Label="Destination Address"
             name="recoveryDestination"
             Width="fill"
           />

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -248,6 +248,12 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'near',
     value: 'near',
   },
+  nep141Token: {
+    Title: 'NEP141 Token',
+    Description: 'Near NEP141 Token',
+    Icon: 'near',
+    value: 'nep141Token',
+  },
   dot: {
     Title: 'DOT',
     Description: 'Polkadot',
@@ -676,6 +682,12 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'near',
     value: 'tnear',
   },
+  tnep141Token: {
+    Title: 'TNEP141 Token',
+    Description: 'Testnet NEP141 Token',
+    Icon: 'near',
+    value: 'tnep141Token',
+  },
   tdot: {
     Title: 'TDOT',
     Description: 'Testnet Polkadot',
@@ -996,6 +1008,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.opeth,
     allCoinMetas.opethToken,
     allCoinMetas.near,
+    allCoinMetas.nep141Token,
     allCoinMetas.polygon,
     allCoinMetas.polygonToken,
     allCoinMetas.bsc,
@@ -1041,6 +1054,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.topeth,
     allCoinMetas.topethToken,
     allCoinMetas.tnear,
+    allCoinMetas.tnep141Token,
     allCoinMetas.tpolygon,
     allCoinMetas.tpolygonToken,
     allCoinMetas.tdoge,
@@ -1100,6 +1114,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.opeth,
       allCoinMetas.opethToken,
       allCoinMetas.near,
+      allCoinMetas.nep141Token,
       allCoinMetas.dot,
       allCoinMetas.tao,
       allCoinMetas.icp,
@@ -1159,6 +1174,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.topeth,
       allCoinMetas.topethToken,
       allCoinMetas.tnear,
+      allCoinMetas.tnep141Token,
       allCoinMetas.tdot,
       allCoinMetas.ttao,
       allCoinMetas.ticp,
@@ -1372,6 +1388,8 @@ export const tokenParentCoins = {
   thbarToken: 'thbar',
   sip10Token: 'stx',
   tsip10Token: 'tstx',
+  nep141Token: 'near',
+  tnep141Token: 'tnear',
 };
 
 export type EvmCcrNonBitgoCoinConfigType = {


### PR DESCRIPTION
NEP141 Token Recoveries:

1. Non-BitGo Recovery

hot wallet with nep141 token fund
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 5 13 04 PM" src="https://github.com/user-attachments/assets/37b7c489-943a-43ba-b4ee-67d1cdaa8051" />

recovery in progress
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 4 57 42 PM" src="https://github.com/user-attachments/assets/b63dbc65-c64c-4fb4-8573-4330ad83648d" />

fully signed transaction data
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 5 12 44 PM" src="https://github.com/user-attachments/assets/77f56388-3c68-4ca9-bdc4-921dd6a7f4c6" />

confirmed transaction on-chain
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 5 14 29 PM" src="https://github.com/user-attachments/assets/dd3959ef-c480-4e0d-8441-d89d2f194b2b" />

2. Build Unsigned Sweep

cold wallet with nep141 token fund
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 5 20 51 PM" src="https://github.com/user-attachments/assets/6e469ed2-99bd-4b8d-aa92-991dd78e1ad1" />

recovery in progress
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 5 19 57 PM" src="https://github.com/user-attachments/assets/9268499c-c156-410e-9d48-f5c304dd0251" />

sign using OVC
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 5 23 50 PM" src="https://github.com/user-attachments/assets/29941bf8-1a05-448e-a3e4-fe45723c3011" />

create broadcastable mpc transaction from fully signed OVC txn
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 6 21 18 PM" src="https://github.com/user-attachments/assets/5c6934ec-9817-4857-bbb0-653a73ab62dd" />

confirmed transaction on-chain
<img width="1728" height="1117" alt="Screenshot 2025-07-30 at 6 57 16 PM" src="https://github.com/user-attachments/assets/bd058e8b-b101-440f-8f3e-13593426ff03" />


Ticket: [COIN-4946](https://bitgoinc.atlassian.net/browse/COIN-4946)

[COIN-4946]: https://bitgoinc.atlassian.net/browse/COIN-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ