### PR TITLE
ci: prevent lockfile modifications via reusable workflow

### DIFF
--- a/.github/workflows/prevent-lockfile-modifications.yaml
+++ b/.github/workflows/prevent-lockfile-modifications.yaml
@@ -1,0 +1,12 @@
+---
+name: Prevent lockfile modifications
+
+on:
+  pull_request:
+
+jobs:
+  prevent-lockfile-modifications:
+    name: Prevent Lockfile Modifications
+    uses: BitGo/static-analysis/.github/workflows/prevent-lockfile-modifications.yaml@v1
+    secrets:
+      vault-cf-access-client-secret: ${{ secrets.VAULT_CF_ACCESS_CLIENT_SECRET }}


### PR DESCRIPTION
As part of incident mitigation, this commit adds a lint that blocks lockfile changes.

See the ticket for more information.

Ticket: DX-1854