### PR TITLE
feat: add support for vet token recoveries

### DIFF
--- a/electron/coinFactory.ts
+++ b/electron/coinFactory.ts
@@ -25,6 +25,8 @@ const tokenParentCoins = {
   txrpToken: 'xrp',
   nep141Token: 'near',
   tnep141Token: 'near',
+  vetToken: 'vet',
+  tvetToken: 'vet',
 };
 
 const CoinFactory = () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -79,7 +79,7 @@ import { Icp, Ticp } from '@bitgo/sdk-coin-icp';
 import { Stx, Tstx, Sip10Token } from '@bitgo/sdk-coin-stx';
 import { Soneium, Tsoneium } from '@bitgo/sdk-coin-soneium';
 import { Polyx, Tpolyx } from '@bitgo/sdk-coin-polyx';
-import { Vet, Tvet } from '@bitgo-beta/sdk-coin-vet';
+import { Vet, Tvet, VetToken } from '@bitgo-beta/sdk-coin-vet';
 import { registerAll as EVMCoinRegisterAll } from '@bitgo/sdk-coin-evm';
 import { CoinFeature, coins } from '@bitgo/statics';
 import { Xtz, Txtz } from '@bitgo/sdk-coin-xtz';
@@ -246,6 +246,9 @@ Sip10Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
   sdk.register(name, coinConstructor);
 });
 Nep141Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
+  sdk.register(name, coinConstructor);
+});
+VetToken.createTokenConstructors().forEach(({ name, coinConstructor }) => {
   sdk.register(name, coinConstructor);
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-placeholder-version",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitgo-beta/sdk-coin-vet": "1.0.0-alpha.90",
+        "@bitgo-beta/sdk-coin-vet": "1.0.1-beta.397",
         "@bitgo-forks/cryptocurrency-icons": "0.25.2",
         "@bitgo/abstract-cosmos": "11.15.7",
         "@bitgo/abstract-substrate": "1.11.7",
@@ -2226,14 +2226,14 @@
       "dev": true
     },
     "node_modules/@bitgo-beta/abstract-eth": {
-      "version": "1.2.3-alpha.412",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/abstract-eth/-/abstract-eth-1.2.3-alpha.412.tgz",
-      "integrity": "sha512-+ZkJdh6+1EDX8xf0KXj2zJv0h3NoklmnDlR8hJLBiLhj/Lu2D/sP9EtzzFpH92PZ8NaEdEze1OeopOcPMREVuQ==",
+      "version": "1.0.2-beta.1515",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/abstract-eth/-/abstract-eth-1.0.2-beta.1515.tgz",
+      "integrity": "sha512-Zlk0n4SefqzdTeZ0Ms5lEkqK7zLwyxna1mRcC85mMUBeLfbgM/61XNNCM0ufnsMKmaTtCGR3R2AJxxCuf6trEg==",
       "dependencies": {
-        "@bitgo-beta/sdk-core": "2.4.1-alpha.412",
-        "@bitgo-beta/sdk-lib-mpc": "8.2.1-alpha.368",
-        "@bitgo-beta/secp256k1": "1.0.1-alpha.370",
-        "@bitgo-beta/statics": "10.0.1-alpha.412",
+        "@bitgo-beta/sdk-core": "8.2.1-beta.1285",
+        "@bitgo-beta/sdk-lib-mpc": "8.2.0-beta.1277",
+        "@bitgo-beta/secp256k1": "1.0.2-beta.1312",
+        "@bitgo-beta/statics": "15.1.1-beta.1288",
         "@ethereumjs/common": "^2.6.5",
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/tx": "^3.3.0",
@@ -2262,18 +2262,18 @@
       }
     },
     "node_modules/@bitgo-beta/blake2b": {
-      "version": "3.2.1-alpha.413",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/blake2b/-/blake2b-3.2.1-alpha.413.tgz",
-      "integrity": "sha512-egapgrTSt8WfnwhPHwrT46vkIlTYsyPqAcD49tTafbddEcTJym8b+tGVn3pWQ0s8YkMfglF/SCj55ieJBfAE6A==",
+      "version": "3.0.4-beta.1523",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/blake2b/-/blake2b-3.0.4-beta.1523.tgz",
+      "integrity": "sha512-iBwjajbwbqHIjkeG+0EAwhVZw8j3Ps+NMe0X1u9qfoh/7eKBR6Xex6i7eLkuHMQhwAQAj3Ei/ozWsx/EYpgH+w==",
       "dependencies": {
-        "@bitgo-beta/blake2b-wasm": "3.2.1-alpha.414",
+        "@bitgo-beta/blake2b-wasm": "3.0.4-beta.1526",
         "nanoassert": "^2.0.0"
       }
     },
     "node_modules/@bitgo-beta/blake2b-wasm": {
-      "version": "3.2.1-alpha.414",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/blake2b-wasm/-/blake2b-wasm-3.2.1-alpha.414.tgz",
-      "integrity": "sha512-Z9gX+F6/uyJ8kOdrEvcpPP8ruAyIlN9h7enIK6c+JLtAKQvtoaZiaemnh4GmzjdbodEyTy42E77ccdpgiZEjtg==",
+      "version": "3.0.4-beta.1526",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/blake2b-wasm/-/blake2b-wasm-3.0.4-beta.1526.tgz",
+      "integrity": "sha512-wN6Vw/0iSEnFII97gOKzlRZ64OrAcwLq63+dzVAWRb0A2hmueYwZk3WL7wpv1rgBAHsOowhcEqqbVkO8eKLlIQ==",
       "dependencies": {
         "nanoassert": "^1.0.0"
       }
@@ -2284,16 +2284,16 @@
       "integrity": "sha512-C40jQ3NzfkP53NsO8kEOFd79p4b9kDXQMwgiY1z8ZwrDZgUyom0AHwGegF4Dm99L+YoYhuaB0ceerUcXmqr1rQ=="
     },
     "node_modules/@bitgo-beta/sdk-coin-vet": {
-      "version": "1.0.0-alpha.90",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/sdk-coin-vet/-/sdk-coin-vet-1.0.0-alpha.90.tgz",
-      "integrity": "sha512-ZklAZO2WcIrCPFeJsAhaUl1J6jzwJVvEvTce16G9kQPRCafZlstwRzMR8mWEfN+EBmF/3sjAl9N2SrfqZObx5A==",
+      "version": "1.0.1-beta.397",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/sdk-coin-vet/-/sdk-coin-vet-1.0.1-beta.397.tgz",
+      "integrity": "sha512-Wj81SkCqJ7apE3QUAXy2RJm+u00Dhts3Hl017Ez6X6opTgLfkAlzgn6hUE4RUKTbakzACmdJZvkrvjEFLRmJDA==",
       "dependencies": {
-        "@bitgo-beta/abstract-eth": "1.2.3-alpha.412",
-        "@bitgo-beta/blake2b": "3.2.1-alpha.413",
-        "@bitgo-beta/sdk-core": "2.4.1-alpha.412",
-        "@bitgo-beta/sdk-lib-mpc": "8.2.1-alpha.368",
-        "@bitgo-beta/secp256k1": "1.0.1-alpha.370",
-        "@bitgo-beta/statics": "10.0.1-alpha.412",
+        "@bitgo-beta/abstract-eth": "1.0.2-beta.1515",
+        "@bitgo-beta/blake2b": "3.0.4-beta.1523",
+        "@bitgo-beta/sdk-core": "8.2.1-beta.1285",
+        "@bitgo-beta/sdk-lib-mpc": "8.2.0-beta.1277",
+        "@bitgo-beta/secp256k1": "1.0.2-beta.1312",
+        "@bitgo-beta/statics": "15.1.1-beta.1288",
         "@noble/curves": "1.8.1",
         "@vechain/sdk-core": "^1.2.0-rc.3",
         "bignumber.js": "^9.1.1",
@@ -2307,16 +2307,16 @@
       }
     },
     "node_modules/@bitgo-beta/sdk-core": {
-      "version": "2.4.1-alpha.412",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/sdk-core/-/sdk-core-2.4.1-alpha.412.tgz",
-      "integrity": "sha512-Tuly5Ud3pCCxIh4zj2bS0oNdItcOd9N1Yc4uYxmyy0iS65I+MUO8CaBVGy3czEeWr0KyFpzDetntsBlLp6NZ3Q==",
+      "version": "8.2.1-beta.1285",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/sdk-core/-/sdk-core-8.2.1-beta.1285.tgz",
+      "integrity": "sha512-3007PkOqSBu0CRRWUPie8GdpCksz52Ea6rmzRNzLTWliRMjqA80BycWUYd9hN0ddY2kFa4APLZh/tEA6eOQ4hg==",
       "dependencies": {
-        "@bitgo-beta/sdk-lib-mpc": "8.2.1-alpha.368",
-        "@bitgo-beta/secp256k1": "1.0.1-alpha.370",
-        "@bitgo-beta/sjcl": "1.0.1-alpha.362",
-        "@bitgo-beta/statics": "10.0.1-alpha.412",
-        "@bitgo-beta/utxo-core": "1.0.1-alpha.143",
-        "@bitgo-beta/utxo-lib": "4.0.1-alpha.413",
+        "@bitgo-beta/sdk-lib-mpc": "8.2.0-beta.1277",
+        "@bitgo-beta/secp256k1": "1.0.2-beta.1312",
+        "@bitgo-beta/sjcl": "1.0.2-beta.1524",
+        "@bitgo-beta/statics": "15.1.1-beta.1288",
+        "@bitgo-beta/utxo-core": "1.8.1-beta.402",
+        "@bitgo-beta/utxo-lib": "8.0.3-beta.1286",
         "@bitgo/public-types": "5.31.0",
         "@noble/curves": "1.8.1",
         "@stablelib/hex": "^1.0.0",
@@ -2372,9 +2372,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/@bitgo-beta/sdk-lib-mpc": {
-      "version": "8.2.1-alpha.368",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/sdk-lib-mpc/-/sdk-lib-mpc-8.2.1-alpha.368.tgz",
-      "integrity": "sha512-IsPyGDKNjfgGlPGsQsenIuBbjIQdav6zuowAJVvkBrAOST9l/e1zfUYXrtc3SfWplLPkcvPiNiCmk1WS6OQptQ==",
+      "version": "8.2.0-beta.1277",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/sdk-lib-mpc/-/sdk-lib-mpc-8.2.0-beta.1277.tgz",
+      "integrity": "sha512-4e9SthA7IfsRzpTDppMBnFQVKnEfxyiXyYmANzfgLHxOOEXWufqKBRU/eiyPClZQ/ZQzWXhGD1quQo8r1R0ksg==",
       "dependencies": {
         "@noble/curves": "1.8.1",
         "@silencelaboratories/dkls-wasm-ll-node": "1.2.0-pre.4",
@@ -2406,9 +2406,9 @@
       "integrity": "sha512-CkqAjnIKFqvo3sCyoBTqgJvF+bHrSik584S9nhTjtBESLx26cbtVMR/T9a6ApChOcSDAaM3JydDmWDUn4EEXng=="
     },
     "node_modules/@bitgo-beta/secp256k1": {
-      "version": "1.0.1-alpha.370",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/secp256k1/-/secp256k1-1.0.1-alpha.370.tgz",
-      "integrity": "sha512-i0JKO8CE8S2J0/149g1crZ+DGkkB9XSmAYLNEFoHjcYthspND1kt6isVs5eNrAPy6jf5BVPLwM30MTydtYPlPA==",
+      "version": "1.0.2-beta.1312",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/secp256k1/-/secp256k1-1.0.2-beta.1312.tgz",
+      "integrity": "sha512-aDqviuCNjNf3MConh9f4QhK5CWyciIe3ep+Cg5hPx5wsqRwZXzzjK1MYY+JKbnKQ4CZDf/2bkOx/xYwHe4ZD1Q==",
       "dependencies": {
         "@brandonblack/musig": "^0.0.1-alpha.0",
         "@noble/secp256k1": "1.6.3",
@@ -2423,34 +2423,34 @@
       }
     },
     "node_modules/@bitgo-beta/sjcl": {
-      "version": "1.0.1-alpha.362",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/sjcl/-/sjcl-1.0.1-alpha.362.tgz",
-      "integrity": "sha512-DMr0xNYcd3qaAeumWRfLa5ngCxjGBJEgxIq0s4FDEBbeTNaSuyPyaWpPjk8g2N4ZfjLz2dX+KGg9JW/iUuRdIQ=="
+      "version": "1.0.2-beta.1524",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/sjcl/-/sjcl-1.0.2-beta.1524.tgz",
+      "integrity": "sha512-3Sf/bLmTmCq4QMdJY4hV4zp1BMOcSBjGxuGhdkXGKfh2Ed1Te10mP6uaLf6AUL4CcBU0raa6Tm9QovxpBZKqWA=="
     },
     "node_modules/@bitgo-beta/statics": {
-      "version": "10.0.1-alpha.412",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/statics/-/statics-10.0.1-alpha.412.tgz",
-      "integrity": "sha512-F6UkNH8lUfLuFh8AK2kSLzsNJgU4wvcpqWK3C9u2VtlVlr71tD/YIFcKehwFnawLzNfw1mzSt4OO/R+1dV3bkA=="
+      "version": "15.1.1-beta.1288",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/statics/-/statics-15.1.1-beta.1288.tgz",
+      "integrity": "sha512-ypsHLrv5Tiu10w/a6CsPbhbfikhA2CUlIr0++g9NpfIOB8Chc/Dgqm95VrMn+yDGhAHBMUECb79HArg1m8RVrQ=="
     },
     "node_modules/@bitgo-beta/unspents": {
-      "version": "0.11.3-alpha.413",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/unspents/-/unspents-0.11.3-alpha.413.tgz",
-      "integrity": "sha512-YNFncoo9Ibf1InFoOosqzbMfxHKUZVpRv9H0CilN7QmsmKKFPmbZU9g8zE/vCMwjWSYzdbCXcE91SVIFRil4sw==",
+      "version": "0.13.2-beta.1285",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/unspents/-/unspents-0.13.2-beta.1285.tgz",
+      "integrity": "sha512-QxCylxVcfCWLjmzK+lHqxOL+6snNLtguKnl7vXq6LjshDNEScN5VKCyNuHFbZjiyjW98rYWi3tskyjIRq3Rmvw==",
       "dependencies": {
-        "@bitgo-beta/utxo-lib": "4.0.1-alpha.413",
+        "@bitgo-beta/utxo-lib": "8.0.3-beta.1286",
         "lodash": "~4.17.21",
         "tcomb": "~3.2.29",
         "varuint-bitcoin": "^1.0.4"
       }
     },
     "node_modules/@bitgo-beta/utxo-core": {
-      "version": "1.0.1-alpha.143",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/utxo-core/-/utxo-core-1.0.1-alpha.143.tgz",
-      "integrity": "sha512-fxnkTmPQDgmOAhaOlIsuyeeypcmr37QhurB6rpnxyZy9xWcipOVzUb3ZzbwZnq/FCxF1nvDK3KfH7EaTA07Yww==",
+      "version": "1.8.1-beta.402",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/utxo-core/-/utxo-core-1.8.1-beta.402.tgz",
+      "integrity": "sha512-ze0fU8C/CEn/Io9qvrYx30DubCaMzelBz4m0eiif644d2iWE61ZMhSqem0Wll4ljO01i1q9evgaTzgkTiOvqAw==",
       "dependencies": {
-        "@bitgo-beta/secp256k1": "1.0.1-alpha.370",
-        "@bitgo-beta/unspents": "0.11.3-alpha.413",
-        "@bitgo-beta/utxo-lib": "4.0.1-alpha.413",
+        "@bitgo-beta/secp256k1": "1.0.2-beta.1312",
+        "@bitgo-beta/unspents": "0.13.2-beta.1285",
+        "@bitgo-beta/utxo-lib": "8.0.3-beta.1286",
         "@bitgo/wasm-miniscript": "2.0.0-beta.7",
         "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
         "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3",
@@ -2458,12 +2458,12 @@
       }
     },
     "node_modules/@bitgo-beta/utxo-lib": {
-      "version": "4.0.1-alpha.413",
-      "resolved": "https://registry.npmjs.org/@bitgo-beta/utxo-lib/-/utxo-lib-4.0.1-alpha.413.tgz",
-      "integrity": "sha512-uC7BfPrjoYkOhHnan3mVtePnk9Qtt0EUNARmEjRiF0JVGUZkJWj6lCeMNNsjrG9N7qZpyrdxjxDSu+UJDxhPZQ==",
+      "version": "8.0.3-beta.1286",
+      "resolved": "https://registry.npmjs.org/@bitgo-beta/utxo-lib/-/utxo-lib-8.0.3-beta.1286.tgz",
+      "integrity": "sha512-4ziQodh6/XGKlzo8MmWM7NZfT5ZtB+tVqK21CNI675mJ9krWRjFEZBvDQw93QsOm6N5kcHh+LV3E+jNAk6Z2mg==",
       "dependencies": {
-        "@bitgo-beta/blake2b": "3.2.1-alpha.413",
-        "@bitgo-beta/secp256k1": "1.0.1-alpha.370",
+        "@bitgo-beta/blake2b": "3.0.4-beta.1523",
+        "@bitgo-beta/secp256k1": "1.0.2-beta.1312",
         "@brandonblack/musig": "^0.0.1-alpha.0",
         "bech32": "^2.0.0",
         "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@bitgo/sdk-coin-tao": "1.12.7",
     "@bitgo/sdk-coin-tia": "3.5.7",
     "@bitgo/sdk-coin-trx": "3.7.4",
-    "@bitgo-beta/sdk-coin-vet": "1.0.0-alpha.90",
+    "@bitgo-beta/sdk-coin-vet": "1.0.1-beta.397",
     "@bitgo/sdk-coin-wemix": "1.5.7",
     "@bitgo/sdk-coin-xdc": "1.5.7",
     "@bitgo/sdk-coin-xlm": "3.7.5",

--- a/src/containers/BuildUnsignedSweepCoin/VetForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/VetForm.tsx
@@ -11,23 +11,38 @@ const validationSchema = Yup.object({
   backupKey: Yup.string(),
 }).required();
 
+type VetFormValues = {
+  bitgoKey: string;
+  recoveryDestination: string;
+  tokenContractAddress?: string;  // optional based on isToken
+}
+
 export type VetFormProps = {
+  isToken: boolean;
   onSubmit: (
     values: VetFormValues,
     formikHelpers: FormikHelpers<VetFormValues>
   ) => void | Promise<void>;
 };
 
-type VetFormValues = Yup.Asserts<typeof validationSchema>;
+export function VetForm({ onSubmit, isToken }: VetFormProps) {
+  const schemaFields: Record<keyof VetFormValues, Yup.AnySchema> = {
+    bitgoKey: Yup.string().required('BitGo Key is required'),
+    recoveryDestination: Yup.string().required('Recovery Destination is required'),
+    tokenContractAddress: isToken
+      ? Yup.string().required('Token contract address is required')
+      : Yup.string().notRequired(),
+  };
 
-export function VetForm({ onSubmit }: VetFormProps) {
+  const validationSchema = Yup.object(schemaFields);
+  const initialValues: VetFormValues = {
+    bitgoKey: '',
+    recoveryDestination: '',
+    ...(isToken ? { tokenContractAddress: '' } : {}),
+  };
+
   const formik = useFormik<VetFormValues>({
-    initialValues: {
-      bitgoKey: '',
-      recoveryDestination: '',
-      userKey: '', // Optional
-      backupKey: '', // Optional
-    },
+    initialValues,
     validationSchema,
     onSubmit,
   });
@@ -55,6 +70,17 @@ export function VetForm({ onSubmit }: VetFormProps) {
             Width="fill"
           />
         </div>
+        { isToken && (
+          <div className="tw-mb-4">
+            <FormikTextfield
+              HelperText="The contract address of the token to recover. This is unique to each token"
+              Label="Token Contract Address"
+              name="tokenContractAddress"
+              Width="fill"
+            />
+          </div>
+        )
+        }
         <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
           <Button Tag={Link} to="/" Variant="secondary" Width="hug">
             Cancel

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -1571,16 +1571,31 @@ function Form() {
       );
     case 'vet':
     case 'tvet':
+    case 'vetToken':
+    case 'tvetToken':
       return (
         <VetForm
           key={coin}
+          isToken={coin === 'vetToken' || coin === 'tvetToken'}
           onSubmit={async (values, { setSubmitting }) => {
             setAlert(undefined);
             setSubmitting(true);
+            const mainnetTokenMap = {
+              '0x0000000000000000000000000000456e65726779': 'vet:vtho',
+            }
+            const testnetTokenMap = {
+              '0x0000000000000000000000000000546573746e6574': 'tvet:vtho',
+            }
             try {
               await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
-              const chainData = await window.queries.getChain(coin);
-              const recoverData = await window.commands.recover(coin, {
+              let parentCoin: string | undefined;
+              if (coin === 'vetToken' || coin === 'tvetToken') {
+                parentCoin = tokenParentCoins[coin];
+              }
+              const chainData = parentCoin ? parentCoin : await window.queries.getChain(coin);
+              let callerCoin = parentCoin ? parentCoin : coin;
+
+              const recoverData = await window.commands.recover(callerCoin, {
                 ...values,
                 ignoreAddressTypes: [],
               });

--- a/src/containers/NonBitGoRecoveryCoin/VetForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/VetForm.tsx
@@ -9,37 +9,54 @@ import {
   FormikTextfield,
 } from '~/components';
 
-const validationSchema = Yup.object({
-  backupKey: Yup.string().required(),
-  bitgoKey: Yup.string().required(),
-  krsProvider: Yup.string()
-    .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
-    .label('Key Recovery Service'),
-  recoveryDestination: Yup.string().required(),
-  userKey: Yup.string().required(),
-  walletPassphrase: Yup.string().required(),
-}).required();
+type VetFormValues = {
+  backupKey: string;
+  bitgoKey: string;
+  krsProvider: string;
+  recoveryDestination: string;
+  userKey: string;
+  walletPassphrase: string;
+  tokenContractAddress?: string;  // optional based on isToken
+}
 
 export type VetFormProps = {
+  isToken: boolean;
   onSubmit: (
     values: VetFormValues,
     formikHelpers: FormikHelpers<VetFormValues>
   ) => void | Promise<void>;
 };
 
-type VetFormValues = Yup.Asserts<typeof validationSchema>;
+export function VetForm({ onSubmit, isToken }: VetFormProps) {
+  const schemaFields: Record<keyof VetFormValues, Yup.AnySchema> = {
+    backupKey: Yup.string().required('Backup Key is required'),
+    bitgoKey: Yup.string().required('BitGo Key is required'),
+    krsProvider: Yup.string()
+      .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
+      .label('Key Recovery Service'),
+    recoveryDestination: Yup.string().required('Recovery Destination is required'),
+    userKey: Yup.string().required('User Key is required'),
+    walletPassphrase: Yup.string().required('WalletPassphrase is required'),
+    tokenContractAddress: isToken
+      ? Yup.string().required('Token contract address is required')
+      : Yup.string().notRequired(),
+  };
 
-export function VetForm({ onSubmit }: VetFormProps) {
+  const validationSchema = Yup.object(schemaFields);
+
+  const initialValues: VetFormValues = {
+    backupKey: '',
+    bitgoKey: '',
+    krsProvider: '',
+    recoveryDestination: '',
+    userKey: '',
+    walletPassphrase: '',
+    ...(isToken ? { tokenContractAddress: '' } : {}),
+  };
+
   const formik = useFormik<VetFormValues>({
     onSubmit,
-    initialValues: {
-      backupKey: '',
-      bitgoKey: '',
-      krsProvider: '',
-      recoveryDestination: '',
-      userKey: '',
-      walletPassphrase: '',
-    },
+    initialValues,
     validationSchema,
   });
 
@@ -110,6 +127,17 @@ export function VetForm({ onSubmit }: VetFormProps) {
             Width="fill"
           />
         </div>
+        { isToken && (
+          <div className="tw-mb-4">
+            <FormikTextfield
+              HelperText="The contract address of the token to recover. This is unique to each token"
+              Label="Token Contract Address"
+              name="tokenContractAddress"
+              Width="fill"
+            />
+          </div>
+        )
+        }
         <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
           <Button Tag={Link} to="/" Variant="secondary" Width="hug">
             Cancel

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -284,6 +284,12 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'vet',
     value: 'vet',
   },
+  vetToken: {
+    Title: 'Vechain Token',
+    Description: 'Vechain VIP180 Token',
+    Icon: 'vet',
+    value: 'vetToken',
+  },
   sol: {
     Title: 'SOL',
     Description: 'Solana',
@@ -736,6 +742,12 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'vet',
     value: 'tvet',
   },
+  tvetToken: {
+    Title: 'Testnet Vechain Token',
+    Description: 'Testnet Vechain VIP180 Token',
+    Icon: 'vet',
+    value: 'tvetToken',
+  },
   tsol: {
     Title: 'TSOL',
     Description: 'Testnet Solana',
@@ -1162,6 +1174,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.polyx,
     allCoinMetas.icp,
     allCoinMetas.vet,
+    allCoinMetas.vetToken,
     allCoinMetas.hbar,
     allCoinMetas.hbarToken,
     allCoinMetas.algo,
@@ -1228,6 +1241,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.tpolyx,
     allCoinMetas.ticp,
     allCoinMetas.tvet,
+    allCoinMetas.tvetToken,
     allCoinMetas.thbar,
     allCoinMetas.thbarToken,
     allCoinMetas.talgo,
@@ -1290,6 +1304,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.polyx,
       allCoinMetas.icp,
       allCoinMetas.vet,
+      allCoinMetas.vetToken,
       allCoinMetas.sol,
       allCoinMetas.solToken,
       allCoinMetas.polygon,
@@ -1358,6 +1373,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.tpolyx,
       allCoinMetas.ticp,
       allCoinMetas.tvet,
+      allCoinMetas.tvetToken,
       allCoinMetas.tsol,
       allCoinMetas.tsolToken,
       allCoinMetas.tpolygon,
@@ -1576,6 +1592,8 @@ export const tokenParentCoins = {
   tsip10Token: 'tstx',
   nep141Token: 'near',
   tnep141Token: 'tnear',
+  vetToken: 'vet',
+  tvetToken: 'tvet',
 };
 
 export type EvmCcrNonBitgoCoinConfigType = {


### PR DESCRIPTION
supported token:
<img width="797" height="613" alt="Screenshot 2025-10-23 at 9 50 02 PM" src="https://github.com/user-attachments/assets/6a645a09-7609-429f-a377-5e88d6deed51" />

withdrawal transaction:
<img width="1448" height="147" alt="Screenshot 2025-10-23 at 9 53 43 PM" src="https://github.com/user-attachments/assets/ef1e4067-946f-414c-98b1-f038d1cf4c93" />

This pull request adds support for Vechain VIP180 tokens (both mainnet and testnet) to the application, enabling users to perform unsigned sweep and non-BitGo recovery operations for these tokens. The changes include updating the SDK dependency, registering the new token types, updating configuration files, and modifying forms to handle the new token-specific fields and logic.

**Vechain VIP180 Token Support**

* Added `vetToken` and `tvetToken` to the list of supported coins for both unsigned sweep and non-BitGo recovery flows, including their metadata and parent coin mappings in `src/helpers/config.ts`. [[1]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R287-R292) [[2]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R745-R750) [[3]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R1177) [[4]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R1244) [[5]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R1307) [[6]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R1376) [[7]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R1595-R1596)

* Registered `VetToken` constructors with the SDK in `electron/main/index.ts` to enable token handling. [[1]](diffhunk://#diff-f055a79f44da9195cf1c6f3c2d04f2dfd22955c4747ce33d281b4538d6720c9cL82-R82) [[2]](diffhunk://#diff-f055a79f44da9195cf1c6f3c2d04f2dfd22955c4747ce33d281b4538d6720c9cR251-R253)

* Updated the parent coin mapping for Vechain tokens in both `electron/coinFactory.ts` and `src/helpers/config.ts`. [[1]](diffhunk://#diff-d58e9a08403b153bbae396e8082c472ad05181ee52be1122136d12368e1eabcfR28-R29) [[2]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R1595-R1596)

**Form and UI Updates**

* Modified the `VetForm` components in both unsigned sweep and non-BitGo recovery flows to support a `tokenContractAddress` field when handling Vechain tokens, with dynamic validation and form field rendering based on whether the coin is a token. [[1]](diffhunk://#diff-aa8f0d7a7397d2256409033d1cd07f5930c718a6c73cd995eb545b73979e12c4R14-R45) [[2]](diffhunk://#diff-aa8f0d7a7397d2256409033d1cd07f5930c718a6c73cd995eb545b73979e12c4R73-R83) [[3]](diffhunk://#diff-664c92611e6cbefc3bf34ff8bbd14ab1a0397733eec3d31471c8b22e95aa69c8L12-R59) [[4]](diffhunk://#diff-664c92611e6cbefc3bf34ff8bbd14ab1a0397733eec3d31471c8b22e95aa69c8R130-R140)

* Updated the logic in form containers (`BuildUnsignedSweepCoin.tsx` and `NonBitGoRecoveryCoin.tsx`) to correctly determine the parent coin, pass the `isToken` prop, and handle the recovery process for tokens. [[1]](diffhunk://#diff-ca96940d021f4e0c95b2a24dda7239ca6f5b5d6375f2782210c7f91edd3fbbc1R1856-R1884) [[2]](diffhunk://#diff-ca96940d021f4e0c95b2a24dda7239ca6f5b5d6375f2782210c7f91edd3fbbc1L1911-R1923) [[3]](diffhunk://#diff-fde9dddd2dd26f3386d15a51febea9404d7dfe3626676b2004cb27f69e957935R1574-R1598)

**Dependency Update**

* Upgraded the `@bitgo-beta/sdk-coin-vet` package to a newer version to support token functionality.

Ticket: COIN-6042