### PR TITLE
fix(build-unsigned-consolodation): unsigned tx instead of signed for hot wallet

### DIFF
--- a/src/containers/BuildUnsignedConsolidation/BuildUnsignedConsolidationCoin.tsx
+++ b/src/containers/BuildUnsignedConsolidation/BuildUnsignedConsolidationCoin.tsx
@@ -46,12 +46,14 @@ function ConsolidationForm({ coin, environment }: ConsolidationFormProps) {
             try {
               await window.commands.setBitGoEnvironment(environment, coin);
               const chainData = await window.queries.getChain(coin);
+              // Exclude walletPassphrase to ensure unsigned transaction
+              const { walletPassphrase, ...recoveryParams } = values;
               const consolidateData =
                 await window.commands.recoverConsolidations(coin, {
-                  ...values,
+                  ...recoveryParams,
                   durableNonces: {
-                    ...values.durableNonces,
-                    publicKeys: values.durableNonces.publicKeys.split(',').map((v) => v.trim()),
+                    ...recoveryParams.durableNonces,
+                    publicKeys: recoveryParams.durableNonces.publicKeys.split(',').map((v) => v.trim()),
                   }
                 });
 
@@ -103,14 +105,16 @@ function ConsolidationForm({ coin, environment }: ConsolidationFormProps) {
               await window.commands.setBitGoEnvironment(environment);
               const parentCoin = coin === 'tsolToken' ? 'tsol' : 'sol';
               const chainData = await window.queries.getChain(parentCoin);
+              // Exclude walletPassphrase to ensure unsigned transaction
+              const { walletPassphrase, ...recoveryParams } = values;
               const consolidateData =
                 await window.commands.recoverConsolidations(parentCoin, {
-                  ...values,
+                  ...recoveryParams,
                   durableNonces: {
-                    ...values.durableNonces,
-                    publicKeys: values.durableNonces.publicKeys.split(',').map((v) => v.trim()),
+                    ...recoveryParams.durableNonces,
+                    publicKeys: recoveryParams.durableNonces.publicKeys.split(',').map((v) => v.trim()),
                   },
-                  programId: values.tokenProgramId,
+                  programId: recoveryParams.tokenProgramId,
                 });
 
               if (consolidateData instanceof Error) {
@@ -166,8 +170,10 @@ function ConsolidationForm({ coin, environment }: ConsolidationFormProps) {
             try {
               await window.commands.setBitGoEnvironment(environment);
               const chainData = await window.queries.getChain(coin);
+              // Exclude walletPassphrase to ensure unsigned transaction
+              const { walletPassphrase, ...recoveryParams } = values;
               const consolidateData =
-                await window.commands.recoverConsolidations(coin, values);
+                await window.commands.recoverConsolidations(coin, recoveryParams);
 
               if (consolidateData instanceof Error) {
                 throw consolidateData;
@@ -215,6 +221,7 @@ function ConsolidationForm({ coin, environment }: ConsolidationFormProps) {
             try {
               await window.commands.setBitGoEnvironment(environment);
               const chainData = await window.queries.getChain(coin);
+              // TronForm doesn't have walletPassphrase, pass values as-is
               const pubsForOvc = await includePubsFor(coin, values);
               const consolidateData =
                 (await window.commands.recoverConsolidations(coin, {
@@ -288,6 +295,7 @@ function ConsolidationForm({ coin, environment }: ConsolidationFormProps) {
               await window.commands.setBitGoEnvironment(environment);
               const parentCoin = coin === 'ttrxToken' ? 'ttrx' : 'trx';
               const chainData = await window.queries.getChain(parentCoin);
+              // TronTokenForm doesn't have walletPassphrase, pass values as-is
               const pubsForOvc = await includePubsFor(parentCoin, values);
               const consolidateData =
                 (await window.commands.recoverConsolidations(parentCoin, {
@@ -361,11 +369,13 @@ function ConsolidationForm({ coin, environment }: ConsolidationFormProps) {
               await window.commands.setBitGoEnvironment(environment);
               const parentCoin = tokenParentCoins[coin];
               const chainData = await window.queries.getChain(parentCoin);
+              // Exclude walletPassphrase to ensure unsigned transaction
+              const { walletPassphrase, ...recoveryParams } = values;
               const consolidateData = await window.commands.recoverConsolidations(parentCoin, {
-                ...(await updateKeysFromIds(parentCoin, values)),
-                bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
-                tokenContractAddress: values.packageId,
-                seed: values.seed,
+                ...(await updateKeysFromIds(parentCoin, recoveryParams)),
+                bitgoKey: recoveryParams.bitgoKey.replace(/\s+/g, ''),
+                tokenContractAddress: recoveryParams.packageId,
+                seed: recoveryParams.seed,
               });
 
               if (consolidateData instanceof Error) {


### PR DESCRIPTION
Fix: Exclude walletPassphrase to ensure unsigned transactions for hot wallets

Previously, hot wallet consolidation was producing signed transactions because 
walletPassphrase was being passed to the SDK, allowing it to decrypt and sign.

Now walletPassphrase and walletType are filtered out before calling 
recoverConsolidations, ensuring unsigned transactions for both cold and hot wallets.

Ticket: WP-1342