### PR TITLE
chore(gha): migrate Mac Intel build from macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
   mac-build_intel:
     name: Create Mac Intel release
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs:
       - get-current-state
     env:


### PR DESCRIPTION
Ticket: WIN-8480

GitHub Actions has retired the macos-13 runner images as of their deprecation schedule. This updates the mac build_intel job to use macos-15-intel, which is the recommended x86_64 Intel replacement and will be supported until August 2027.

Reference: https://github.com/actions/runner-images/issues/13046