### PR TITLE
COIN-7747: Add isTss option to ERC20 token recovery forms

### DIFF
--- a/src/containers/BuildUnsignedSweepCoin/EthLikeTokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/EthLikeTokenForm.tsx
@@ -1,4 +1,4 @@
-import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
+import { Field, Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
 import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
 import { Button, FormikTextfield } from '~/components';
@@ -13,6 +13,7 @@ const validationSchema = Yup.object({
     .integer()
     .positive('Gas limit must be a positive integer')
     .required(),
+  isTss: Yup.boolean(),
   maxFeePerGas: Yup.number().required(),
   maxPriorityFeePerGas: Yup.number().required(),
   recoveryDestination: Yup.string().required(),
@@ -43,6 +44,7 @@ export function EthLikeTokenForm({
       backupKey: '',
       backupKeyId: '',
       gasLimit: allCoinMetas[coinName]?.defaultGasLimitNum ?? 500000,
+      isTss: false,
       maxFeePerGas: allCoinMetas[coinName]?.defaultMaxFeePerGas ?? 20,
       maxPriorityFeePerGas:
         allCoinMetas[coinName]?.defaultMaxPriorityFeePerGas ?? 10,
@@ -155,6 +157,14 @@ export function EthLikeTokenForm({
             Width="fill"
           />
         </div>
+        {allCoinMetas[coinName].isTssSupported && (
+          <div className="tw-mb-4" role="group">
+            <label>
+              <Field type="checkbox" name="isTss" />
+              Is TSS recovery?
+            </label>
+          </div>
+        )}
         <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
           <Button Tag={Link} to="/" Variant="secondary" Width="hug">
             Cancel

--- a/src/containers/NonBitGoRecoveryCoin/EthLikeTokenForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/EthLikeTokenForm.tsx
@@ -1,4 +1,4 @@
-import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
+import { Field, Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
 import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
 import {
@@ -14,6 +14,7 @@ const validationSchema = Yup.object({
   apiKey: Yup.string().required(),
   backupKey: Yup.string().required(),
   gasLimit: Yup.number().required(),
+  isTss: Yup.boolean(),
   krsProvider: Yup.string()
     .oneOf(['keyternal', 'bitgoKRSv2', 'dai'])
     .label('Key Recovery Service'),
@@ -46,6 +47,7 @@ export function EthLikeTokenForm({
       apiKey: '',
       userKey: '',
       backupKey: '',
+      isTss: false,
       tokenContractAddress: '',
       walletContractAddress: '',
       walletPassphrase: '',
@@ -175,6 +177,14 @@ export function EthLikeTokenForm({
             Width="fill"
           />
         </div>
+        {allCoinMetas[coinName].isTssSupported && (
+          <div className="tw-mb-4" role="group">
+            <label>
+              <Field type="checkbox" name="isTss" />
+              Is TSS recovery?
+            </label>
+          </div>
+        )}
         <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
           <Button Tag={Link} to="/" Variant="secondary" Width="hug">
             Cancel

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -91,6 +91,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     value: 'erc20',
     minGasLimit: '30,000',
     defaultGasLimit: '500,000',
+    isTssSupported: true,
   },
   trx: {
     Title: 'TRX',
@@ -153,6 +154,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     minGasLimit: '400,000',
     defaultGasLimit: '1,000,000',
     defaultGasLimitNum: 1000000,
+    isTssSupported: true,
   },
   coredao: {
     Title: 'COREDAO',
@@ -241,6 +243,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     minGasLimit: '400,000',
     defaultGasLimit: '500,000',
     defaultGasLimitNum: 500000,
+    isTssSupported: true,
   },
   near: {
     Title: 'NEAR',
@@ -333,6 +336,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     defaultGasLimitNum: 500000,
     defaultMaxPriorityFeePerGas: 30,
     defaultMaxFeePerGas: 50,
+    isTssSupported: true,
   },
   bcha: {
     Title: 'BCHA',
@@ -580,6 +584,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     value: 'hterc20',
     minGasLimit: '30,000',
     defaultGasLimit: '500,000',
+    isTssSupported: true,
   },
   ttrx: {
     Title: 'TTRX',
@@ -630,6 +635,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     minGasLimit: '400,000',
     defaultGasLimit: '500,000',
     defaultGasLimitNum: 500000,
+    isTssSupported: true,
   },
   tcoredao: {
     Title: 'TCOREDAO',
@@ -718,6 +724,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     minGasLimit: '400,000',
     defaultGasLimit: '500,000',
     defaultGasLimitNum: 500000,
+    isTssSupported: true,
   },
   tnear: {
     Title: 'TNEAR',
@@ -820,6 +827,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     defaultGasLimitNum: 500000,
     defaultMaxPriorityFeePerGas: 30,
     defaultMaxFeePerGas: 50,
+    isTssSupported: true,
   },
   tdoge: {
     Title: 'TDOGE',


### PR DESCRIPTION
## Summary

Add the missing "Is TSS recovery?" checkbox to ERC20 token recovery forms in both the unsigned sweep and non-BitGo recovery flows, and enable `isTssSupported` in coin config for applicable EVM token coins.

**Jira**: [COIN-7747](https://bitgoinc.atlassian.net/browse/COIN-7747)

## Changes

- Add `isTss` boolean field to `EthLikeTokenForm` validation schema and initial values in `BuildUnsignedSweepCoin`
- Add `isTss` boolean field to `EthLikeTokenForm` validation schema and initial values in `NonBitGoRecoveryCoin`
- Import `Field` from formik and render "Is TSS recovery?" checkbox when `isTssSupported` is true
- Enable `isTssSupported: true` in `config.ts` for ERC20 token coins (erc20, hterc20, arbethToken, tarbethToken, opethToken, topethToken, polygonToken, tpolygonToken)

## Test Plan

- Verify the "Is TSS recovery?" checkbox appears for ERC20 token coins in both unsigned sweep and non-BitGo recovery flows
- Verify the checkbox does not appear for coins without `isTssSupported`
- Verify TSS recovery flow works end-to-end when the checkbox is selected

COIN-7747

[COIN-7747]: https://bitgoinc.atlassian.net/browse/COIN-7747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ