### PR TITLE
docs(ada): add ada recovery broadcast instructions and script

### DIFF
--- a/UNSIGNED_CONSOLIDATE_RECOVER.md
+++ b/UNSIGNED_CONSOLIDATE_RECOVER.md
@@ -38,6 +38,7 @@ Build a file containing a list of unsigned consolidation recovery transactions t
 12. **Broadcast the signed transactions:**
     - Copy the fully-signed (or half-signed for TRON) transaction file to an internet-connected machine.
     - Use the appropriate broadcast method for your coin.
+    - **For Cardano (ADA / TADA):** See the [Cardano broadcast instructions](#cardano-ada--tada) section below.
 
 ## What coins are supported?
 
@@ -56,3 +57,61 @@ Build a file containing a list of unsigned consolidation recovery transactions t
 - **Test Bittensor (TTAO)**
 - **Test Solana (TSOL)** and test SPL tokens
 - **Test Sui (TSUI)** and test Sui tokens
+
+---
+
+## Cardano (ADA / TADA)
+
+### Supported assets
+
+- **ADA** (mainnet) and **TADA** (Preprod testnet)
+- Native tokens (e.g. fungible tokens on the Cardano blockchain)
+
+When a receive address holds native tokens alongside ADA, the consolidation transaction for that address produces **two outputs**:
+- Token output: root address + tokens + 1.5 ADA (minimum UTXO requirement)
+- ADA remainder: root address + remaining ADA after fee
+
+### Signing with OVC (6-step EdDSA)
+
+Cardano uses **EdDSA (Ed25519)**, so signing takes **6 steps** in OVC.
+
+> **Important:** Select **Sign TSS Recoveries** in OVC — not "Sign Transactions" or "Sign TSS Transactions".
+
+| Step | OVC role   | Action |
+|------|------------|--------|
+| 1    | User OVC   | Upload unsigned consolidation file → download share file |
+| 2    | Backup OVC | Upload user share → download backup share |
+| 3    | User OVC   | Upload backup share → download user signature share |
+| 4    | Backup OVC | Upload user signature share → download backup signature share |
+| 5    | User OVC   | Upload backup signature share → download final signed file |
+| 6    | —          | Broadcast each transaction in the signed file |
+
+### Multiple transactions per file
+
+WRW produces **one unsigned transaction per funded receive address**. If two addresses have funds, the signed file will contain two `signatureShares` entries. You must **broadcast each transaction separately** — they are independent on-chain transactions.
+
+### Broadcast using `broadcast_ada.py`
+
+`broadcast_ada.py` (included in this repository) assembles and submits all transactions in the signed file automatically, in order.
+
+**Requirements:**
+```bash
+pip install cbor2
+```
+
+**Broadcast to testnet (TADA / Preprod):**
+```bash
+python3 broadcast_ada.py path/to/SIGNED-ovc-signed-part-6-of-6-<timestamp>.json
+```
+
+**Broadcast to mainnet (ADA):**
+```bash
+python3 broadcast_ada.py path/to/SIGNED-ovc-signed-part-6-of-6-<timestamp>.json --network mainnet
+```
+
+**Dry run (inspect assembled CBOR without broadcasting):**
+```bash
+python3 broadcast_ada.py path/to/SIGNED-ovc-signed-part-6-of-6-<timestamp>.json --dry-run
+```
+
+The script iterates over every `signatureShares` entry, prints the transaction details, broadcasts each one, and prints the Cardanoscan explorer link for each successful submission.

--- a/UNSIGNED_SWEEP.md
+++ b/UNSIGNED_SWEEP.md
@@ -58,6 +58,8 @@ Build an unsigned transaction from a cold wallet using the user and backup publi
 
     Bitcoin Gold transactions: https://btgexplorer.com/sendtx
 
+    Cardano transactions: See [Cardano (ADA / TADA)](#cardano-ada--tada) section below.
+
     EOS transactions: [EOS.md](EOS.md)
 
     Ethereum and ERC20 Token transactions: https://etherscan.io/pushTx
@@ -71,3 +73,65 @@ Build an unsigned transaction from a cold wallet using the user and backup publi
     Stellar transactions: https://laboratory.stellar.org/#txsubmitter?network=public
 
     Tron transactions: https://www.btcschools.net/tron/tron_broadcast_tx.php
+
+---
+
+## Cardano (ADA / TADA)
+
+Cardano uses **EdDSA (Ed25519)** signing, so the OVC signing process takes **6 steps** instead of the standard 2.
+
+### Supported assets
+
+- **ADA** (mainnet) and **TADA** (Preprod testnet)
+- Native tokens (e.g. fungible tokens on the Cardano blockchain)
+
+When the wallet holds both ADA and native tokens, WRW produces **two outputs** in the unsigned sweep:
+- Token output: destination address + tokens + 1.5 ADA (Cardano minimum UTXO requirement)
+- ADA remainder: destination address + remaining ADA after fee
+
+### Step 1 — Build the unsigned sweep file in WRW
+
+1. Select coin **ADA** or **TADA**.
+2. Enter your **User Public Key**, **Backup Public Key**, and **BitGo Public Key** from your KeyCard.
+3. Enter the **destination address**.
+4. Click **Recover Funds**. WRW saves e.g. `ada-unsigned-sweep-<timestamp>.json`.
+
+### Step 2 — Sign offline using OVC (6-step EdDSA)
+
+> **Important:** Select **Sign TSS Recoveries** in OVC — not "Sign Transactions" or "Sign TSS Transactions".
+> Recovery files have no server-backed `txRequestId`; the standard signing flow will fail.
+
+| Step | OVC role   | Action |
+|------|------------|--------|
+| 1    | User OVC   | Upload unsigned sweep file → download share file |
+| 2    | Backup OVC | Upload user share → download backup share |
+| 3    | User OVC   | Upload backup share → download user signature share |
+| 4    | Backup OVC | Upload user signature share → download backup signature share |
+| 5    | User OVC   | Upload backup signature share → download final signed file |
+| 6    | —          | Broadcast the final signed file |
+
+### Step 3 — Broadcast using `broadcast_ada.py`
+
+`broadcast_ada.py` (included in this repository) assembles the signed CBOR from the OVC output and submits it to the Cardano network via Koios.
+
+**Requirements:**
+```bash
+pip install cbor2
+```
+
+**Broadcast to testnet (TADA / Preprod):**
+```bash
+python3 broadcast_ada.py path/to/SIGNED-ovc-signed-part-6-of-6-<timestamp>.json
+```
+
+**Broadcast to mainnet (ADA):**
+```bash
+python3 broadcast_ada.py path/to/SIGNED-ovc-signed-part-6-of-6-<timestamp>.json --network mainnet
+```
+
+**Dry run (assemble CBOR without broadcasting):**
+```bash
+python3 broadcast_ada.py path/to/SIGNED-ovc-signed-part-6-of-6-<timestamp>.json --dry-run
+```
+
+On success, the script prints the transaction hash and a Cardanoscan explorer link.

--- a/broadcast_ada.py
+++ b/broadcast_ada.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Assemble a fully-signed Cardano transaction from OVC output and broadcast
+via the Koios API.
+
+Supports both mainnet (ADA) and Preprod testnet (TADA).
+
+Usage:
+  python3 broadcast_ada.py <FullySigned.json> [--dry-run] [--network mainnet|preprod]
+
+Options:
+  --dry-run              Assemble and print signed CBOR without broadcasting.
+  --network mainnet      Broadcast to Cardano mainnet via Koios.
+  --network preprod      Broadcast to Cardano Preprod testnet via Koios (default).
+
+Requirements:
+  pip install cbor2
+
+The signed JSON file is the output of the OVC "Sign TSS Recoveries" flow.
+For consolidation runs with multiple funded addresses, one signatureShares
+entry is produced per address. This script broadcasts all of them in order.
+"""
+
+import sys
+import json
+import cbor2
+import urllib.request
+import urllib.error
+
+KOIOS_PREPROD = "https://preprod.koios.rest/api/v1/submittx"
+KOIOS_MAINNET  = "https://api.koios.rest/api/v1/submittx"
+
+def assemble_signed_tx(unsigned_cbor_hex: str, vkey_hex: str, r_hex: str, sigma_hex: str) -> str:
+    """
+    Replace the empty witness set in the unsigned transaction CBOR with a
+    single Ed25519 vkey-witness built from the OVC EdDSA signature components.
+
+    Cardano tx structure (array of 4):
+      [transaction_body, transaction_witness_set, bool (validity), aux_data]
+
+    vkeywitness = [vkey (32 bytes), signature (64 bytes)]
+    signature   = R (32 bytes) || sigma (32 bytes)
+    """
+    raw = bytes.fromhex(unsigned_cbor_hex)
+    tx  = cbor2.loads(raw)
+
+    assert isinstance(tx, list) and len(tx) == 4, \
+        f"Expected Cardano tx array(4), got: {type(tx)} len={len(tx)}"
+
+    tx_body, _witness_set, valid_flag, aux_data = tx
+
+    vkey      = bytes.fromhex(vkey_hex)       # 32 bytes – public key
+    signature = bytes.fromhex(r_hex + sigma_hex)  # 64 bytes – R || sigma
+
+    assert len(vkey) == 32,      f"vkey must be 32 bytes, got {len(vkey)}"
+    assert len(signature) == 64, f"signature must be 64 bytes, got {len(signature)}"
+
+    # Cardano vkeywitness set: { 0: [[vkey, sig]] }
+    witness_set = {0: [[vkey, signature]]}
+
+    signed_tx = [tx_body, witness_set, valid_flag, aux_data]
+    return cbor2.dumps(signed_tx).hex()
+
+
+def broadcast(signed_cbor_hex: str, network: str = "preprod") -> dict:
+    url     = KOIOS_PREPROD if network == "preprod" else KOIOS_MAINNET
+    payload = bytes.fromhex(signed_cbor_hex)
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/cbor"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode()
+            return {"status": resp.status, "txHash": body.strip().strip('"')}
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        return {"status": e.code, "error": body}
+
+
+def main():
+    args     = sys.argv[1:]
+    dry_run  = "--dry-run" in args
+
+    network = "preprod"
+    if "--network" in args:
+        idx = args.index("--network")
+        if idx + 1 < len(args):
+            network = args[idx + 1]
+            if network not in ("mainnet", "preprod"):
+                print(f"ERROR: --network must be 'mainnet' or 'preprod', got '{network}'")
+                sys.exit(1)
+        else:
+            print("ERROR: --network requires a value (mainnet or preprod)")
+            sys.exit(1)
+
+    json_args = [a for a in args if not a.startswith("--") and a not in ("mainnet", "preprod")]
+
+    if not json_args:
+        print("Usage: python3 broadcast_ada.py <FullySigned.json> [--dry-run] [--network mainnet|preprod]")
+        sys.exit(1)
+
+    with open(json_args[0]) as f:
+        data = json.load(f)
+
+    # FullySigned.json produced by OVC has structure:
+    #   { signatureShares: [ { txRequest: { transactions: [...] }, ovc: [...] } ] }
+    # When consolidating multiple addresses, there is one signatureShare per address.
+    sig_shares = data["signatureShares"]
+    if not sig_shares:
+        print("ERROR: No signature shares found in file.")
+        sys.exit(1)
+
+    for idx, sig_share in enumerate(sig_shares):
+        tx_entry  = sig_share["txRequest"]["transactions"][0]
+        ovc_sig   = sig_share["ovc"][0]["eddsaSignature"]
+
+        unsigned_cbor = tx_entry["unsignedTx"]["serializedTx"]
+        vkey_hex      = ovc_sig["y"]    # public key (32 bytes)
+        r_hex         = ovc_sig["R"]    # nonce commitment (32 bytes)
+        sigma_hex     = ovc_sig["sigma"]  # signature scalar (32 bytes)
+
+        scan_idx = tx_entry.get("unsignedTx", {}).get("scanIndex", idx + 1)
+        print(f"\n--- Transaction {idx + 1}/{len(sig_shares)} (scanIndex={scan_idx}) ---")
+        print(f"Unsigned CBOR : {unsigned_cbor[:60]}...")
+        print(f"Public key (y): {vkey_hex}")
+        print(f"R              : {r_hex}")
+        print(f"sigma          : {sigma_hex}")
+
+        signed_cbor = assemble_signed_tx(unsigned_cbor, vkey_hex, r_hex, sigma_hex)
+        print(f"Signed CBOR length: {len(signed_cbor) // 2} bytes")
+
+        if dry_run:
+            print(f"\n[dry-run] Would broadcast transaction {idx + 1}. Skipping.")
+            if idx == 0:
+                print(f"Full signed CBOR hex:\n{signed_cbor}")
+            continue
+
+        network_label = "mainnet" if network == "mainnet" else "Preprod testnet"
+        print(f"\nBroadcasting transaction {idx + 1}/{len(sig_shares)} to Cardano {network_label} via Koios…")
+        result = broadcast(signed_cbor, network=network)
+
+        if "txHash" in result and result.get("status") == 202:
+            print(f"Success! Tx Hash : {result['txHash']}")
+            explorer_base = "https://cardanoscan.io" if network == "mainnet" else "https://preprod.cardanoscan.io"
+            print(f"Explorer: {explorer_base}/transaction/{result['txHash']}")
+        else:
+            print(f"Broadcast response: {result}")
+
+    if dry_run and len(sig_shares) > 1:
+        print(f"\n[dry-run] Total: {len(sig_shares)} transaction(s) would be broadcast.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ticket: CSHLD-542

Description:

- Update UNSIGNED_SWEEP.md and UNSIGNED_CONSOLIDATE_RECOVER.md with Cardano-specific OVC signing steps (6-step EdDSA), multi-tx broadcast guidance, and broadcast_ada.py usage examples.



- Added broadcast_ada.py for assembling and broadcasting signed Cardano transactions from OVC output. Supports mainnet and Preprod testnet via --network flag.

