### PR TITLE
feat: add inketh wallet recovery support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-placeholder-version",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitgo-forks/cryptocurrency-icons": "0.98.0",
+        "@bitgo-forks/cryptocurrency-icons": "0.101.0",
         "@bitgo/abstract-cosmos": "11.17.7",
         "@bitgo/abstract-substrate": "1.13.8",
         "@bitgo/abstract-utxo": "10.20.0",
@@ -75,7 +75,7 @@
         "@bitgo/sdk-coin-zec": "2.7.8",
         "@bitgo/sdk-coin-zeta": "3.6.8",
         "@bitgo/sdk-opensslbytes": "2.1.0",
-        "@bitgo/statics": "58.38.0",
+        "@bitgo/statics": "58.39.0",
         "@bitgo/utxo-lib": "11.21.0",
         "@ethereumjs/common": "2.6.5",
         "@lottiefiles/react-lottie-player": "3.4.9",
@@ -2287,9 +2287,9 @@
       }
     },
     "node_modules/@bitgo-forks/cryptocurrency-icons": {
-      "version": "0.98.0",
-      "resolved": "https://registry.npmjs.org/@bitgo-forks/cryptocurrency-icons/-/cryptocurrency-icons-0.98.0.tgz",
-      "integrity": "sha512-oOk0zvb0OGwY7noCGT8N1H7LGn/H/Ec5EIFS4XKGUGB9DApms6IiqIR9I1exIIV6i0GDVZ07DFONCVmv9DUvVw==",
+      "version": "0.101.0",
+      "resolved": "https://registry.npmjs.org/@bitgo-forks/cryptocurrency-icons/-/cryptocurrency-icons-0.101.0.tgz",
+      "integrity": "sha512-fZTplNL2lx1cV3f7NhfzUPiY/SuCDwh+17mkv/gVIszryQKj6+iI/x5kaghPVht5vRe7csvssUrOiuP22zPSjw==",
       "license": "CC0-1.0",
       "engines": {
         "node": ">=20.19.0"
@@ -4384,9 +4384,9 @@
       "integrity": "sha512-dBICMzShC8gXdpSj9cvl4wl9Jkt4h14wt4XQ+/6V6qcC2IObyKRJfaG5TYUU6RvVknhPBPyBx9v84vNKODM5fQ=="
     },
     "node_modules/@bitgo/statics": {
-      "version": "58.38.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-58.38.0.tgz",
-      "integrity": "sha512-gL+XGtfy8cRPb+zx86oSo4TsOuw8L7vkfatKfKH8TJD3/o8GbN0XeHrL6HSXyqruHHL3Zl98+Vn4qQTeeBQ+wA==",
+      "version": "58.39.0",
+      "resolved": "https://registry.npmjs.org/@bitgo/statics/-/statics-58.39.0.tgz",
+      "integrity": "sha512-lsvLPJudk6VBhoq4xJWSufkRlBo9fatfvmrB133Ige4nKBSyzzvJhEDJ95E1MeNdLtSEj2isVG4Qa2nToZxiCg==",
       "license": "Apache-2.0"
     },
     "node_modules/@bitgo/unspents": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@polkadot/x-randomvalues": "13.3.1",
-    "@bitgo-forks/cryptocurrency-icons": "0.98.0",
+    "@bitgo-forks/cryptocurrency-icons": "0.101.0",
     "@bitgo/abstract-cosmos": "11.17.7",
     "@bitgo/abstract-substrate": "1.13.8",
     "@bitgo/abstract-utxo": "10.20.0",
@@ -76,7 +76,7 @@
     "@bitgo/sdk-coin-zec": "2.7.8",
     "@bitgo/sdk-coin-zeta": "3.6.8",
     "@bitgo/sdk-opensslbytes": "2.1.0",
-    "@bitgo/statics": "58.38.0",
+    "@bitgo/statics": "58.39.0",
     "@bitgo/utxo-lib": "11.21.0",
     "@ethereumjs/common": "2.6.5",
     "@lottiefiles/react-lottie-player": "3.4.9",

--- a/src/components/CryptocurrencyIcon/get-dynamic-icon.ts
+++ b/src/components/CryptocurrencyIcon/get-dynamic-icon.ts
@@ -1967,6 +1967,8 @@ export const getDynamicIcon = (name: string) => {
       return lazy(() => import('@bitgo-forks/cryptocurrency-icons/react/injv2'));
     case 'ink':
       return lazy(() => import('@bitgo-forks/cryptocurrency-icons/react/ink'));
+    case 'inketh':
+      return lazy(() => import('@bitgo-forks/cryptocurrency-icons/react/inketh'));
     case 'ins':
       return lazy(() => import('@bitgo-forks/cryptocurrency-icons/react/ins'));
     case 'inst':

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -87,6 +87,8 @@ const evmCoins = [
   'themieth',
   'usdt0',
   'tusdt0',
+  'inketh',
+  'tinketh',
   ...testEvmUnsignedSweepCoins,
   ...prodEvmUnsignedSweepCoins,
 ];

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -79,6 +79,8 @@ const evmCoins = [
   'themieth',
   'usdt0',
   'tusdt0',
+  'inketh',
+  'tinketh',
   ...testEvmNonBitgoRecoveryCoins,
   ...prodEvmNonBitgoRecoveryCoins,
 ];

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1524,6 +1524,22 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     ApiKeyProvider: 'testnet.stablescan.xyz',
     isTssSupported: true,
   },
+  inketh: {
+    Title: 'INKETH',
+    Description: 'INK Ethereum Mainnet',
+    Icon: 'inketh',
+    value: 'inketh',
+    ApiKeyProvider: 'explorer.inkonchain.com',
+    isTssSupported: true,
+  },
+  tinketh: {
+    Title: 'TINKETH',
+    Description: 'INK Ethereum Testnet',
+    Icon: 'inketh',
+    value: 'tinketh',
+    ApiKeyProvider: 'explorer-sepolia.inkonchain.com',
+    isTssSupported: true,
+  },
 } as const;
 
 function assertMetadata(coin: string): boolean {
@@ -1673,6 +1689,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.dydxcosmos,
     allCoinMetas.hemieth,
     allCoinMetas.usdt0,
+    allCoinMetas.inketh,
     ...prodEvmUnsignedSweepCoins.map(coin => allCoinMetas[coin]),
   ] as const,
   test: [
@@ -1744,6 +1761,7 @@ export const buildUnsignedSweepCoins: Record<
     allCoinMetas.tdydxcosmos,
     allCoinMetas.themieth,
     allCoinMetas.tusdt0,
+    allCoinMetas.tinketh,
     ...testEvmUnsignedSweepCoins.map(coin => allCoinMetas[coin]),
   ] as const,
 };
@@ -1825,6 +1843,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.dydxcosmos,
       allCoinMetas.hemieth,
       allCoinMetas.usdt0,
+      allCoinMetas.inketh,
       ...prodEvmNonBitgoRecoveryCoins.map(coin => allCoinMetas[coin]),
     ] as const,
     test: [
@@ -1896,6 +1915,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.tdydxcosmos,
       allCoinMetas.themieth,
       allCoinMetas.tusdt0,
+      allCoinMetas.tinketh,
       ...testEvmNonBitgoRecoveryCoins.map(coin => allCoinMetas[coin]),
     ] as const,
   };


### PR DESCRIPTION
## Summary
- Adds `inketh` and `tinketh` (INK Ethereum mainnet/testnet) support for wallet recovery
- Bumps `@bitgo-forks/cryptocurrency-icons` to `0.101.0`
- Bumps `@bitgo/statics` to `58.39.0`

## Changes
- `get-dynamic-icon.ts`: added `inketh` icon case
- `BuildUnsignedSweepCoin.tsx`: added `inketh`/`tinketh` to EVM coins
- `NonBitGoRecoveryCoin.tsx`: added `inketh`/`tinketh` to EVM coins
- `config.ts`: added `inketh`/`tinketh` metadata, buildUnsignedSweepCoins, nonBitgoRecoveryCoins entries

## Test plan
- [x] Verify inketh appears in the Non-BitGo Recovery coin selector
- [x] Verify inketh icon renders correctly

CECHO-765