### PR TITLE
feat: add Solana nested ATA recovery to wallet-recovery-wizard

### DIFF
--- a/e2e/sol/nested-ata-recovery.spec.ts
+++ b/e2e/sol/nested-ata-recovery.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, _electron as electron } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+
+const MOCK_TX_ID = 'mockTxId1234567890abcdef';
+
+function stubNestedAtaHandlers(app: ElectronApplication) {
+  return app.evaluate(
+    ({ ipcMain }, txId) => {
+      for (const ch of ['setBitGoEnvironment', 'recoverNestedAta'])
+        ipcMain.removeHandler(ch);
+      ipcMain.handle('setBitGoEnvironment', () => undefined);
+      ipcMain.handle('recoverNestedAta', () => ({ txId }));
+    },
+    MOCK_TX_ID
+  );
+}
+
+test.describe('Solana nested ATA recovery', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeEach(async () => {
+    app = await electron.launch({ args: ['.', '--no-sandbox'] });
+    page = await app.firstWindow();
+    await page.waitForSelector('#root');
+    await stubNestedAtaHandlers(app);
+  });
+
+  test.afterEach(async () => {
+    await app.close();
+  });
+
+  test('renders NestedATAForm for solNestedATA coin', async () => {
+    await page.evaluate(() => {
+      window.location.hash = '/prod/non-bitgo-recovery/solNestedATA';
+    });
+
+    await page.waitForSelector('[name="nestedAtaAddress"]');
+
+    await expect(page.locator('[name="userKey"]')).toBeVisible();
+    await expect(page.locator('[name="backupKey"]')).toBeVisible();
+    await expect(page.locator('[name="bitgoKey"]')).toBeVisible();
+    await expect(page.locator('[name="walletPassphrase"]')).toBeVisible();
+    await expect(page.locator('[name="recoveryDestination"]')).toBeVisible();
+    await expect(page.locator('[name="nestedAtaAddress"]')).toBeVisible();
+    await expect(page.locator('[name="ownerAtaAddress"]')).toBeVisible();
+    await expect(page.locator('[name="tokenMintAddress"]')).toBeVisible();
+  });
+
+  test('shows validation errors when submitted empty', async () => {
+    await page.evaluate(() => {
+      window.location.hash = '/prod/non-bitgo-recovery/solNestedATA';
+    });
+    await page.waitForSelector('[name="nestedAtaAddress"]');
+
+    await page.click('button[type="submit"]');
+
+    // Formik marks fields as touched on submit — the Textarea component signals
+    // errors via tw-border-red-500 (not aria-invalid)
+    await expect(page.locator('[name="userKey"]')).toHaveClass(/tw-border-red-500/);
+    await expect(page.locator('[name="nestedAtaAddress"]')).toHaveClass(/tw-border-red-500/);
+  });
+
+  test('completes recovery and shows txId on success page', async () => {
+    await page.evaluate(() => {
+      window.location.hash = '/prod/non-bitgo-recovery/solNestedATA';
+    });
+    await page.waitForSelector('[name="nestedAtaAddress"]');
+
+    await page.fill('[name="userKey"]',            '{"iv":"abc","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","ct":"encryptedUserKey"}');
+    await page.fill('[name="backupKey"]',           '{"iv":"def","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","ct":"encryptedBackupKey"}');
+    await page.fill('[name="bitgoKey"]',            'xpub661MyMwAqRbcGHoJePkfLFqgzNBjqAqMjZaRVPMd3su2mTJ7HJQNFVkBkzVHBG7yWVZvLgXSZDmDj8mqqVFnzWijVhKanGj6ygSWfzFQ6eB');
+    await page.fill('[name="walletPassphrase"]',    'test-passphrase-123');
+    await page.fill('[name="recoveryDestination"]', '7YbcLmVorrH7KCKMj38rFidsruisWi2CmvCTs4cygf8K');
+    await page.fill('[name="nestedAtaAddress"]',    'FGuZSBhtreqSUsE86xokyjKz2i8VBtJzy6uMXXKyGHug');
+    await page.fill('[name="ownerAtaAddress"]',     'Zfm98ZpVafydhFTYcsY6bHgubhB4cFgWFvbdEJxYhTA');
+    await page.fill('[name="tokenMintAddress"]',    'ZBCNpuD7YMXzTHB2fhGkGi78MNsHGLRXUhRewNRm9RU');
+
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL(/non-bitgo-recovery\/solNestedATA\/success/, { timeout: 10_000 });
+    await expect(page.getByText(MOCK_TX_ID)).toBeVisible();
+    await expect(page.getByText('View on Solscan')).toBeVisible();
+  });
+
+  test('renders NestedATAForm for tsolNestedATA coin (testnet)', async () => {
+    await page.evaluate(() => {
+      window.location.hash = '/test/non-bitgo-recovery/tsolNestedATA';
+    });
+    await page.waitForSelector('[name="nestedAtaAddress"]');
+    await expect(page.locator('[name="nestedAtaAddress"]')).toBeVisible();
+  });
+});

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -458,6 +458,12 @@ async function createWindow() {
     );
   });
 
+  ipcMain.handle('recoverNestedAta', async (event, coin, parameters) => {
+    const baseCoin = sdk.coin(coin) as Sol;
+    const openSSLBytes = loadWebAssembly().buffer;
+    return await baseCoin.recoverNestedAta({ ...parameters, openSSLBytes });
+  });
+
   ipcMain.handle('broadcastTransaction', async (event, coin, parameters) => {
     const baseCoin = sdk.coin(coin);
     return await baseCoin.broadcastTransaction(parameters);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -81,6 +81,21 @@ type Commands = {
   showSaveDialog(
     options: Electron.SaveDialogOptions
   ): Promise<Electron.SaveDialogReturnValue>;
+  recoverNestedAta(
+    coin: string,
+    parameters: {
+      userKey: string;
+      backupKey: string;
+      bitgoKey: string;
+      walletPassphrase: string;
+      recoveryDestination: string;
+      nestedAtaAddress: string;
+      ownerAtaAddress: string;
+      tokenMintAddress: string;
+      apiKey?: string;
+      seed?: string;
+    }
+  ): Promise<{ txId?: string }>;
   recover(
     coin: string,
     parameters: RecoverParams & {
@@ -204,6 +219,9 @@ const commands: Commands = {
   },
   showSaveDialog(options) {
     return ipcRenderer.invoke('showSaveDialog', options);
+  },
+  recoverNestedAta(coin, parameters) {
+    return ipcRenderer.invoke('recoverNestedAta', coin, parameters);
   },
   recover(coin, parameters) {
     return ipcRenderer.invoke('recover', coin, parameters);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,7 @@ export default tseslint.config(
       'eslint.config.mjs',
       // Fails at the parser level — must use ignores, not per-file overrides
       'src/components/Title/Title.test.tsx',
+      'src/containers/NonBitGoRecoveryCoin/NestedATAForm.test.tsx',
     ],
   },
 

--- a/src/containers/NonBitGoRecoveryCoin/NestedATAForm.test.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NestedATAForm.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { NestedATAForm } from './NestedATAForm';
+
+function renderForm(onSubmit = vi.fn()) {
+  const result = render(
+    <MemoryRouter>
+      <NestedATAForm onSubmit={onSubmit} />
+    </MemoryRouter>
+  );
+  const q = (name: string) =>
+    result.container.querySelector<HTMLElement>(`[name="${name}"]`)!;
+  return { ...result, q };
+}
+
+function fillValidForm(q: (name: string) => HTMLElement) {
+  fireEvent.change(q('userKey'), {
+    target: { value: '{"iv":"abc","ct":"encryptedUserKey"}' },
+  });
+  fireEvent.change(q('backupKey'), {
+    target: { value: '{"iv":"def","ct":"encryptedBackupKey"}' },
+  });
+  fireEvent.change(q('bitgoKey'), {
+    target: { value: 'xpubBitGoKey' },
+  });
+  fireEvent.change(q('walletPassphrase'), {
+    target: { value: 'test-passphrase' },
+  });
+  fireEvent.change(q('recoveryDestination'), {
+    target: { value: '7YbcLmVorrH7KCKMj38rFidsruisWi2CmvCTs4cygf8K' },
+  });
+  fireEvent.change(q('nestedAtaAddress'), {
+    target: { value: 'FGuZSBhtreqSUsE86xokyjKz2i8VBtJzy6uMXXKyGHug' },
+  });
+  fireEvent.change(q('ownerAtaAddress'), {
+    target: { value: 'Zfm98ZpVafydhFTYcsY6bHgubhB4cFgWFvbdEJxYhTA' },
+  });
+  fireEvent.change(q('tokenMintAddress'), {
+    target: { value: 'ZBCNpuD7YMXzTHB2fhGkGi78MNsHGLRXUhRewNRm9RU' },
+  });
+}
+
+describe('NestedATAForm', () => {
+  it('renders all required fields', () => {
+    const { q } = renderForm();
+
+    expect(q('userKey')).not.toBeNull();
+    expect(q('backupKey')).not.toBeNull();
+    expect(q('bitgoKey')).not.toBeNull();
+    expect(q('walletPassphrase')).not.toBeNull();
+    expect(q('recoveryDestination')).not.toBeNull();
+    expect(q('nestedAtaAddress')).not.toBeNull();
+    expect(q('ownerAtaAddress')).not.toBeNull();
+    expect(q('tokenMintAddress')).not.toBeNull();
+    expect(q('apiKey')).not.toBeNull();
+  });
+
+  it('renders submit button with correct label', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /recover tokens/i })).not.toBeNull();
+  });
+
+  it('calls onSubmit with correct values when form is valid', async () => {
+    const onSubmit = vi.fn();
+    const { q } = renderForm(onSubmit);
+
+    fillValidForm(q);
+    fireEvent.click(screen.getByRole('button', { name: /recover tokens/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+      const [values] = onSubmit.mock.calls[0] as [Record<string, string>][];
+      expect(values.nestedAtaAddress).toBe('FGuZSBhtreqSUsE86xokyjKz2i8VBtJzy6uMXXKyGHug');
+      expect(values.ownerAtaAddress).toBe('Zfm98ZpVafydhFTYcsY6bHgubhB4cFgWFvbdEJxYhTA');
+      expect(values.tokenMintAddress).toBe('ZBCNpuD7YMXzTHB2fhGkGi78MNsHGLRXUhRewNRm9RU');
+      expect(values.recoveryDestination).toBe('7YbcLmVorrH7KCKMj38rFidsruisWi2CmvCTs4cygf8K');
+    });
+  });
+
+  it('does not call onSubmit when required fields are empty', async () => {
+    const onSubmit = vi.fn();
+    renderForm(onSubmit);
+
+    fireEvent.click(screen.getByRole('button', { name: /recover tokens/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects API key that looks like a URL', async () => {
+    const onSubmit = vi.fn();
+    const { q } = renderForm(onSubmit);
+
+    fillValidForm(q);
+    fireEvent.change(q('apiKey'), {
+      target: { value: 'https://eth-mainnet.g.alchemy.com/v2/somekey' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /recover tokens/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/api key should not be a url/i)).not.toBeNull();
+    });
+  });
+
+  it('accepts a valid optional API key', async () => {
+    const onSubmit = vi.fn();
+    const { q } = renderForm(onSubmit);
+
+    fillValidForm(q);
+    fireEvent.change(q('apiKey'), {
+      target: { value: 'validApiKey123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /recover tokens/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/containers/NonBitGoRecoveryCoin/NestedATAForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NestedATAForm.tsx
@@ -1,0 +1,169 @@
+import { Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
+import { Link } from 'react-router-dom';
+import * as Yup from 'yup';
+import {
+  Button,
+  FormikPasswordfield,
+  FormikTextarea,
+  FormikTextfield,
+  Icon,
+  Notice,
+} from '~/components';
+
+const validationSchema = Yup.object({
+  userKey: Yup.string().required(),
+  backupKey: Yup.string().required(),
+  bitgoKey: Yup.string().required(),
+  walletPassphrase: Yup.string().required(),
+  recoveryDestination: Yup.string().required(),
+  nestedAtaAddress: Yup.string().required(),
+  ownerAtaAddress: Yup.string().required(),
+  tokenMintAddress: Yup.string().required(),
+  apiKey: Yup.string().test(
+    'not-url-or-alchemy',
+    'API key should not be a URL',
+    (value) => {
+      if (!value) return true;
+      return !value.match(/^https?:\/\//i) && !value.toLowerCase().includes('alchemy');
+    }
+  ),
+}).required();
+
+export type NestedATAFormProps = {
+  onSubmit: (
+    values: NestedATAFormValues,
+    formikHelpers: FormikHelpers<NestedATAFormValues>
+  ) => void | Promise<void>;
+};
+
+type NestedATAFormValues = Yup.Asserts<typeof validationSchema>;
+
+export function NestedATAForm({ onSubmit }: NestedATAFormProps) {
+  const formik = useFormik<NestedATAFormValues>({
+    onSubmit,
+    initialValues: {
+      userKey: '',
+      backupKey: '',
+      bitgoKey: '',
+      walletPassphrase: '',
+      recoveryDestination: '',
+      nestedAtaAddress: '',
+      ownerAtaAddress: '',
+      tokenMintAddress: '',
+      apiKey: '',
+    },
+    validationSchema,
+  });
+
+  return (
+    <FormikProvider value={formik}>
+      <Form>
+        <div className="tw-mb-8">
+          <Notice
+            Variant="Secondary"
+            IconLeft={<Icon Name="warning-sign" Size="small" />}
+          >
+            This flow recovers tokens stuck in a nested Associated Token Account
+            (an ATA whose owner is another ATA). The transaction will be signed
+            and broadcast immediately.
+          </Notice>
+        </div>
+        <h4 className="tw-text-body tw-font-semibold tw-border-b-0.5 tw-border-solid tw-border-gray-700 tw-mb-4">
+          Wallet KeyCard details
+        </h4>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText="Your encrypted user key, as found on your recovery KeyCard (Box A)."
+            Label="Box A Value"
+            name="userKey"
+            rows={4}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText="Your encrypted backup key, as found on your recovery KeyCard (Box B)."
+            Label="Box B Value"
+            name="backupKey"
+            rows={4}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextarea
+            HelperText="The BitGo public key for the wallet, as found on your recovery KeyCard (Box C)."
+            Label="Box C Value"
+            name="bitgoKey"
+            rows={2}
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikPasswordfield
+            HelperText="The passphrase of the wallet."
+            Label="Wallet Passphrase"
+            name="walletPassphrase"
+            Width="fill"
+          />
+        </div>
+        <h4 className="tw-text-body tw-font-semibold tw-border-b-0.5 tw-border-solid tw-border-gray-700 tw-mb-4 tw-mt-6">
+          Recovery addresses
+        </h4>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The root address of your wallet (shown on your BitGo dashboard)."
+            Label="Wallet Root Address"
+            name="recoveryDestination"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The nested ATA address that holds the stuck tokens."
+            Label="Nested ATA Address"
+            name="nestedAtaAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The owner ATA address (tokens will be moved here)."
+            Label="Owner ATA Address"
+            name="ownerAtaAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="The token mint address for the stuck token."
+            Label="Token Mint Address"
+            name="tokenMintAddress"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-mb-4">
+          <FormikTextfield
+            HelperText="An API Key Token from alchemy.com (optional)."
+            Label="API Key (optional)"
+            name="apiKey"
+            Width="fill"
+          />
+        </div>
+        <div className="tw-flex tw-flex-col-reverse sm:tw-justify-between sm:tw-flex-row tw-gap-1 tw-mt-4">
+          <Button Tag={Link} to="/" Variant="secondary" Width="hug">
+            Cancel
+          </Button>
+          <Button
+            Variant="primary"
+            Width="hug"
+            type="submit"
+            Disabled={formik.isSubmitting}
+            disabled={formik.isSubmitting}
+          >
+            {formik.isSubmitting ? 'Recovering...' : 'Recover Tokens'}
+          </Button>
+        </div>
+      </Form>
+    </FormikProvider>
+  );
+}

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.tsx
@@ -30,6 +30,7 @@ import { PolkadotForm } from './PolkadotForm';
 import { RippleForm } from './RippleForm';
 import { SolanaForm } from './SolanaForm';
 import { SolanaTokenForm } from './SolanaTokenForm';
+import { NestedATAForm } from './NestedATAForm';
 import { TronForm } from './TronForm';
 import { TronTokenForm } from './TronTokenForm';
 import { AvalancheCTokenForm } from './AvalancheCTokenForm';
@@ -515,6 +516,44 @@ function Form() {
           }}
         />
       );
+    case 'solNestedATA':
+    case 'tsolNestedATA': {
+      const parentCoin = coin === 'solNestedATA' ? 'sol' : 'tsol';
+      return (
+        <NestedATAForm
+          key={coin}
+          onSubmit={async (values, { setSubmitting }) => {
+            setAlert(undefined);
+            setSubmitting(true);
+            try {
+              await window.commands.setBitGoEnvironment(bitGoEnvironment, coin);
+              const result = await window.commands.recoverNestedAta(parentCoin, {
+                userKey: values.userKey,
+                backupKey: values.backupKey,
+                bitgoKey: values.bitgoKey.replace(/\s+/g, ''),
+                walletPassphrase: values.walletPassphrase,
+                recoveryDestination: values.recoveryDestination,
+                nestedAtaAddress: values.nestedAtaAddress,
+                ownerAtaAddress: values.ownerAtaAddress,
+                tokenMintAddress: values.tokenMintAddress,
+                apiKey: values.apiKey || undefined,
+              });
+              navigate(
+                `/${bitGoEnvironment}/non-bitgo-recovery/${coin}/success`,
+                { state: { txId: result.txId } }
+              );
+            } catch (err) {
+              if (err instanceof Error) {
+                setAlert(err.message);
+              } else {
+                console.error(err);
+              }
+              setSubmitting(false);
+            }
+          }}
+        />
+      );
+    }
     case 'ethw':
       return (
         <EthereumWForm

--- a/src/containers/SuccessfulRecovery/SuccessfulRecovery.tsx
+++ b/src/containers/SuccessfulRecovery/SuccessfulRecovery.tsx
@@ -1,9 +1,12 @@
 import { Player } from '@lottiefiles/react-lottie-player';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Button } from '../../components';
 import CelebrationCheck from './CelebrationCheck.json';
 
 export function SuccessfulRecovery() {
+  const location = useLocation();
+  const txId = (location.state as { txId?: string } | null)?.txId;
+
   return (
     <div className="tw-flex-col tw-items-center tw-p-16">
       <div className="tw-px-8 tw-mb-2">
@@ -15,12 +18,34 @@ export function SuccessfulRecovery() {
             style={{ height: '100px', width: '100px' }}
           />
         </div>
-        <div className="tw-text-center tw-text-label-1 tw-text-gray-900 tw-pb-2 tw-max-w-prose">
-          We recommend that you use a third-party API to decode your txHex and
-          verify its accuracy before broadcasting.
-        </div>
+        {txId ? (
+          <div className="tw-text-center tw-pb-2 tw-max-w-prose">
+            <div className="tw-text-label-1 tw-text-gray-900 tw-mb-2">
+              Transaction broadcast successfully.
+            </div>
+            <div className="tw-text-label-2 tw-text-gray-700 tw-mb-1">
+              Transaction ID:
+            </div>
+            <div className="tw-font-mono tw-text-xs tw-break-all tw-mb-3">
+              {txId}
+            </div>
+            <a
+              href={`https://solscan.io/tx/${txId}`}
+              target="_blank"
+              rel="noreferrer"
+              className="tw-text-blue-500 tw-underline"
+            >
+              View on Solscan &rarr;
+            </a>
+          </div>
+        ) : (
+          <div className="tw-text-center tw-text-label-1 tw-text-gray-900 tw-pb-2 tw-max-w-prose">
+            We recommend that you use a third-party API to decode your txHex and
+            verify its accuracy before broadcasting.
+          </div>
+        )}
       </div>
-      <div className="tw-flex tw-justify-center">
+      <div className="tw-flex tw-justify-center tw-mt-4">
         <Button Tag={Link} to="/" Variant="secondary" Width="hug">
           Back to Home &rarr;
         </Button>

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -305,6 +305,12 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'sol',
     value: 'solToken',
   },
+  solNestedATA: {
+    Title: 'SOL Nested ATA',
+    Description: 'Recover tokens stuck in a Solana nested Associated Token Account',
+    Icon: 'sol',
+    value: 'solNestedATA',
+  },
   polygon: {
     Title: 'POLYGON',
     Description: 'POLYGON Chain',
@@ -785,6 +791,12 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Description: 'Testnet Solana Token',
     Icon: 'sol',
     value: 'tsolToken',
+  },
+  tsolNestedATA: {
+    Title: 'TSOL Nested ATA',
+    Description: 'Recover tokens stuck in a Solana nested Associated Token Account (Testnet)',
+    Icon: 'sol',
+    value: 'tsolNestedATA',
   },
   tsoneium: {
     Title: 'TSONEIUM',
@@ -1813,6 +1825,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.vetToken,
       allCoinMetas.sol,
       allCoinMetas.solToken,
+      allCoinMetas.solNestedATA,
       allCoinMetas.polygon,
       allCoinMetas.polygonToken,
       allCoinMetas.bsc,
@@ -1890,6 +1903,7 @@ export const nonBitgoRecoveryCoins: Record<BitgoEnv, readonly CoinMetadata[]> =
       allCoinMetas.tvetToken,
       allCoinMetas.tsol,
       allCoinMetas.tsolToken,
+      allCoinMetas.tsolNestedATA,
       allCoinMetas.tpolygon,
       allCoinMetas.tpolygonToken,
       allCoinMetas.tbsc,

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -98,6 +98,21 @@ type Commands = {
   showSaveDialog(
     options: Electron.SaveDialogOptions
   ): Promise<Electron.SaveDialogReturnValue>;
+  recoverNestedAta(
+    coin: string,
+    parameters: {
+      userKey: string;
+      backupKey: string;
+      bitgoKey: string;
+      walletPassphrase: string;
+      recoveryDestination: string;
+      nestedAtaAddress: string;
+      ownerAtaAddress: string;
+      tokenMintAddress: string;
+      apiKey?: string;
+      seed?: string;
+    }
+  ): Promise<{ txId?: string }>;
   recover(
     coin: string,
     parameters: RecoverParams & {


### PR DESCRIPTION
## Summary

- Adds **SOL Nested ATA** / **TSOL Nested ATA** as new coin options under Non-BitGo Recovery, allowing clients to self-serve recovery of SPL tokens stuck in a nested Associated Token Account (an ATA whose owner is another ATA)
- Wires a new `recoverNestedAta` IPC command that calls `Sol.recoverNestedAta()` from the SDK
- New `NestedATAForm` collects all required keycard fields (Box A/B/C, passphrase) plus the three ATA addresses
- Success page now shows transaction ID and a direct Solscan link when a txId is returned
- Bumps node engine constraint to `>=20.10.0` and pins `uuid` to `^8.3.2` to fix ESM/CJS conflict from `@solana/buffer-layout-utils`

## Context

Fixes the support case in COINS-148 / COIN-7674 where a customer's ZBCN token balance (~37,741 tokens) was stuck in a nested ATA and showed 0 spendable. Previously the only option was asking the client to run a Node.js script manually.

## Test plan

- [ ] `yarn install --ignore-engines && yarn dev` launches the Electron app
- [ ] Non-BitGo Recovery → Prod → **SOL Nested ATA** renders the `NestedATAForm` with all 8 fields
- [ ] Submitting with empty fields shows Yup validation errors
- [ ] Submitting with invalid addresses surfaces the SDK error message in the UI
- [ ] Submitting with valid keycard + ATA addresses broadcasts the transaction and the success page displays the txId with a Solscan link
- [ ] All other existing recovery flows are unaffected (success page falls back to generic message when no txId in route state)

TICKET: COINS-148