### PR TITLE
feat(wrw): add ECX self-custody recovery via light BTC path

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,5 +1,6 @@
 import { TrxConsolidationRecoveryOptions, RecoverWithPsbtParams, SignPsbtParams } from '../types';
 import { isUtxoCoin, isXprv, psbtToHex, signPsbt, signPsbtWithBothKeys } from '../utxo/psbt';
+import * as utxoRecovery from '../utxo';
 import type { RecoveryCoin } from '../recoveryCoin';
 import EthereumCommon from '@ethereumjs/common';
 
@@ -312,12 +313,15 @@ function assertsIsAbstractUtxoCoin(
 }
 
 /**
- * Resolve a coin name to a unified RecoveryCoin.  SDK coins are wrapped so
+ * Resolve a coin name to a unified RecoveryCoin.  Non-SDK UTXO coins (e.g.
+ * ECX) are handled by their strategy module; SDK coins are wrapped so
  * the IPC handlers can call recover/broadcast/deriveKeyWithSeed/getChain
- * uniformly without branching on coin type.  Non-SDK coins (added in a
- * follow-up) provide their own RecoveryCoin implementation.
+ * uniformly without branching on coin type.
  */
 function getRecoveryCoin(coinName: string): RecoveryCoin {
+  if (utxoRecovery.isNonSdkUtxoCoin(coinName)) {
+    return utxoRecovery.getNonSdkUtxoCoin(sdk, coinName);
+  }
   const baseCoin = sdk.coin(coinName);
   return {
     deriveKeyWithSeed: (key, seed) =>

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,5 +1,6 @@
 import { TrxConsolidationRecoveryOptions, RecoverWithPsbtParams, SignPsbtParams } from '../types';
 import { isUtxoCoin, isXprv, psbtToHex, signPsbt, signPsbtWithBothKeys } from '../utxo/psbt';
+import type { RecoveryCoin } from '../recoveryCoin';
 import EthereumCommon from '@ethereumjs/common';
 
 // Allow self-signed / intermediate-CA certs when running in dev mode.
@@ -310,6 +311,39 @@ function assertsIsAbstractUtxoCoin(
   );
 }
 
+/**
+ * Resolve a coin name to a unified RecoveryCoin.  SDK coins are wrapped so
+ * the IPC handlers can call recover/broadcast/deriveKeyWithSeed/getChain
+ * uniformly without branching on coin type.  Non-SDK coins (added in a
+ * follow-up) provide their own RecoveryCoin implementation.
+ */
+function getRecoveryCoin(coinName: string): RecoveryCoin {
+  const baseCoin = sdk.coin(coinName);
+  return {
+    deriveKeyWithSeed: (key, seed) =>
+      baseCoin.deriveKeyWithSeed({ key, seed }),
+    getChain: () => baseCoin.getChain(),
+    async recover(parameters) {
+      const params = parameters as {
+        ethCommonParams?: Partial<Record<string, unknown>>;
+        common?: unknown;
+        [key: string]: unknown;
+      };
+      if (params.ethCommonParams) {
+        params.common = EthereumCommon.custom(params.ethCommonParams);
+      }
+      const openSSLBytes = loadWebAssembly().buffer;
+      return await (baseCoin as AbstractEthLikeNewCoins).recover(
+        { ...params, openSSLBytes },
+        openSSLBytes
+      );
+    },
+    async broadcast(parameters) {
+      return await baseCoin.broadcastTransaction(parameters);
+    },
+  };
+}
+
 async function createWindow() {
   win = new BrowserWindow({
     title: 'Wallet Recovery Wizard',
@@ -462,20 +496,7 @@ async function createWindow() {
   );
 
   ipcMain.handle('recover', async (event, coin, parameters) => {
-    const baseCoin = sdk.coin(coin) as AbstractEthLikeNewCoins;
-    if (parameters.ethCommonParams) {
-      parameters.common = EthereumCommon.custom({
-        ...parameters.ethCommonParams,
-      });
-    }
-    const openSSLBytes = loadWebAssembly().buffer;
-    return await baseCoin.recover(
-      {
-        ...parameters,
-        openSSLBytes,
-      },
-      openSSLBytes
-    );
+    return getRecoveryCoin(coin).recover(parameters);
   });
 
   ipcMain.handle('recoverNestedAta', async (event, coin, parameters) => {
@@ -485,8 +506,7 @@ async function createWindow() {
   });
 
   ipcMain.handle('broadcastTransaction', async (event, coin, parameters) => {
-    const baseCoin = sdk.coin(coin);
-    return await baseCoin.broadcastTransaction(parameters);
+    return getRecoveryCoin(coin).broadcast(parameters);
   });
 
   ipcMain.handle('recoverConsolidations', async (event, coin, params) => {
@@ -575,7 +595,7 @@ async function createWindow() {
   });
 
   ipcMain.handle('deriveKeyWithSeed', (event, coin, key, seed) => {
-    return sdk.coin(coin).deriveKeyWithSeed({ key, seed });
+    return getRecoveryCoin(coin).deriveKeyWithSeed(key, seed);
   });
 
   ipcMain.handle('deriveKeyByPath', (event, key, id) => {
@@ -585,7 +605,7 @@ async function createWindow() {
   });
 
   ipcMain.handle('getChain', (event, coin) => {
-    return sdk.coin(coin).getChain();
+    return getRecoveryCoin(coin).getChain();
   });
 
   ipcMain.handle('getUser', () => {

--- a/electron/recoveryCoin.ts
+++ b/electron/recoveryCoin.ts
@@ -1,0 +1,16 @@
+/**
+ * Unified interface for coin operations used by the WRW IPC handlers.
+ *
+ * SDK coins are wrapped by getRecoveryCoin() so that non-SDK coins (coins not
+ * registered in the BitGo SDK) can provide their own implementation and the
+ * IPC handlers don't need to branch on coin type.
+ */
+export interface RecoveryCoin {
+  deriveKeyWithSeed(
+    key: string,
+    seed: string
+  ): { key: string; derivationPath: string };
+  getChain(): string;
+  recover(parameters: unknown): Promise<unknown>;
+  broadcast(parameters: unknown): Promise<string>;
+}

--- a/electron/utxo/ecx.test.ts
+++ b/electron/utxo/ecx.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/require-await, @typescript-eslint/unbound-method */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { createEcxCoin } from './ecx';
+import { BitGoAPI } from '@bitgo/sdk-api';
+import { Btc } from '@bitgo/sdk-coin-btc';
+import { BIP32, fixedScriptWallet, Transaction } from '@bitgo/wasm-utxo';
+import type { RecoveryProvider, RecoverParams } from '@bitgo/abstract-utxo';
+
+const { RootWalletKeys, ChainCode, address } = fixedScriptWallet;
+
+const KEYCHAINS = [
+  {
+    pub: 'xpub661MyMwAqRbcGiQhVk1J7cD1YodF9tc5Y1B8vpTjjB1pcB1J1m1QX8fMtYP2sYqFmW6J2ra69tNoARKjvTGo9cGUrbPbJdjwrSzGGzPzWWS',
+    prv: 'xprv9s21ZrQH143K4ELEPiUHkUGGzmnkkRtEAnFY8S48AqUqjNg9UDh9yLLt3FcfATyCjbsMB9JCGHAD8MeBTAK1P7trFppkoswu5ZAsHYASfbk',
+  },
+  {
+    pub: 'xpub661MyMwAqRbcFzLXuganogQvd7MrefQQqCcJP2ZDumnCdQecf5cw1P1nD5qBz8SNS1yCLSC9VqpNUWnQU3V6qmnPt2r21oXhicQFzPA6Lby',
+    prv: 'xprv9s21ZrQH143K3WG4of3nSYUC55XNFCgZTyghae9cMSFDkcKU7YJgTahJMpdTY9CjCcjgSo2TJ635uUVx176BufUMBFpieKYVJD9J3VvrGRm',
+  },
+  {
+    pub: 'xpub661MyMwAqRbcFHpwWrzPB61U2CgBmdD21WNVM1JKUn9rEExkoGE4yafUVFbPSd78vdX8tWcEUQWaALFkU9fUbUM4Cc49DKEJSCYGRnbzCym',
+    prv: 'xprv9s21ZrQH143K2okUQqTNox4jUAqhNAVAeHStYcthvScsMSdcFiupRnLzdxzfJithak5Zs92FQJeeJ9Jiya63KfUNxawuMZDCp2cGT9cdMKs',
+  },
+];
+
+const ECX_REPLAY_LOCK_TIME = 499_999_999;
+const RECOVERY_DESTINATION = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const COIN_NAME = 'btc';
+const UNSPENT_VALUE = 100_000_000;
+
+type WasmWalletKeys = ReturnType<typeof buildWalletKeys>;
+
+function buildWalletKeys() {
+  const xpubs = KEYCHAINS.map((k) => BIP32.from(k.pub));
+  return RootWalletKeys.from({
+    triple: xpubs,
+    derivationPrefixes: ['m/0/0', 'm/0/0', 'm/0/0'],
+  });
+}
+
+function deriveP2wshAddress(walletKeys: WasmWalletKeys): string {
+  const chain = ChainCode.value('p2wsh', 'external');
+  return address(walletKeys, chain, 0, COIN_NAME);
+}
+
+function createMockRecoveryProvider(unspentAddress: string): RecoveryProvider {
+  const unspent = {
+    id: 'ab'.repeat(32) + ':0',
+    address: unspentAddress,
+    value: UNSPENT_VALUE,
+  };
+
+  return {
+    async getAddressInfo(a: string) {
+      if (a === unspentAddress)
+        return { txCount: 1, balance: UNSPENT_VALUE };
+      return { txCount: 0, balance: 0 };
+    },
+    async getUnspentsForAddresses(addresses: string[]) {
+      return [unspent].filter((u) => addresses.includes(u.address));
+    },
+    async getTransactionHex(): Promise<string> {
+      throw new Error('not needed for segwit inputs');
+    },
+    async getTransactionIO() {
+      throw new Error('not implemented');
+    },
+  };
+}
+
+function buildRecoverParams(
+  walletKeys: WasmWalletKeys,
+  lockTime: number,
+): RecoverParams {
+  const addr = deriveP2wshAddress(walletKeys);
+  return {
+    userKey: KEYCHAINS[0].prv,
+    backupKey: KEYCHAINS[1].prv,
+    bitgoKey: KEYCHAINS[2].pub,
+    recoveryDestination: RECOVERY_DESTINATION,
+    recoveryProvider: createMockRecoveryProvider(addr),
+    feeRate: 100,
+    scan: 1,
+    ignoreAddressTypes: ['p2sh', 'p2shP2wsh', 'p2trLegacy', 'p2trMusig2'],
+    lockTime,
+  };
+}
+
+function extractTxHex(result: Record<string, unknown>): string {
+  return (result.transactionHex ?? result.txHex) as string;
+}
+
+describe('createEcxCoin', () => {
+  it('sets lockTime = 499_999_999 in recover params', async () => {
+    const mockRecover = vi.fn().mockResolvedValue({});
+    const mockBaseCoin = {
+      deriveKeyWithSeed: vi.fn(),
+      getChain: vi.fn().mockReturnValue('btc'),
+      recover: mockRecover,
+    };
+    const mockSdk = {
+      coin: vi.fn().mockReturnValue(mockBaseCoin),
+      getEnv: vi.fn().mockReturnValue('prod'),
+    };
+
+    const ecxCoin = createEcxCoin(mockSdk as any);
+
+    await ecxCoin.recover({
+      userKey: 'xpub-user',
+      backupKey: 'xpub-backup',
+      bitgoKey: 'xpub-bitgo',
+      recoveryDestination: 'ecx-addr',
+    });
+
+    expect(mockRecover).toHaveBeenCalledTimes(1);
+    const recoverParams = mockRecover.mock.calls[0][0] as Record<string, unknown>;
+    expect(recoverParams.lockTime).toBe(ECX_REPLAY_LOCK_TIME);
+  });
+});
+
+describe('SDK recover() lockTime sensitivity', () => {
+  let coin: any;
+  let walletKeys: WasmWalletKeys;
+
+  beforeAll(() => {
+    const sdk = new BitGoAPI({ env: 'test' });
+    sdk.register('btc', Btc.createInstance);
+    coin = sdk.coin('btc');
+    walletKeys = buildWalletKeys();
+  });
+
+  it('encodes lockTime=499_999_999 in the recovered transaction', async () => {
+    const result = (await coin.recover(
+      buildRecoverParams(walletKeys, ECX_REPLAY_LOCK_TIME),
+    )) as Record<string, unknown>;
+    const hex = extractTxHex(result);
+    const tx = Transaction.fromBytes(Buffer.from(hex, 'hex'), COIN_NAME);
+    expect(tx.lockTime()).toBe(ECX_REPLAY_LOCK_TIME);
+  });
+
+  it('encodes lockTime=0 when lockTime is set to 0', async () => {
+    const result = (await coin.recover(
+      buildRecoverParams(walletKeys, 0),
+    )) as Record<string, unknown>;
+    const hex = extractTxHex(result);
+    const tx = Transaction.fromBytes(Buffer.from(hex, 'hex'), COIN_NAME);
+    expect(tx.lockTime()).toBe(0);
+  });
+
+  it('produces different transactions for different lockTime values', async () => {
+    const resultWithLock = (await coin.recover(
+      buildRecoverParams(walletKeys, ECX_REPLAY_LOCK_TIME),
+    )) as Record<string, unknown>;
+    const resultWithoutLock = (await coin.recover(
+      buildRecoverParams(walletKeys, 0),
+    )) as Record<string, unknown>;
+
+    const hexWithLock = extractTxHex(resultWithLock);
+    const hexWithoutLock = extractTxHex(resultWithoutLock);
+
+    expect(hexWithLock).not.toBe(hexWithoutLock);
+  });
+});

--- a/electron/utxo/ecx.ts
+++ b/electron/utxo/ecx.ts
@@ -83,7 +83,7 @@ export function createEcxCoin(sdk: BitGoAPI): RecoveryCoin {
     // ECX unsigned sweeps are written to a file and signed/broadcast outside
     // WRW (see BuildUnsignedSweepCoin.tsx) — 'tecx' is not in
     // broadcastTransactionCoins, so this is unreachable from the UI.
-    async broadcast() {
+    broadcast() {
       throw new Error(
         'ECX recovery does not support broadcasting through WRW; sign and broadcast the unsigned sweep externally.'
       );

--- a/electron/utxo/ecx.ts
+++ b/electron/utxo/ecx.ts
@@ -1,0 +1,92 @@
+import type { RecoveryCoin } from '../recoveryCoin';
+import {
+  AbstractUtxoCoin,
+  type RecoveryProvider,
+  type RecoverParams,
+} from '@bitgo/abstract-utxo';
+import { BlockstreamApi } from '@bitgo/blockapis';
+import type { BitGoAPI } from '@bitgo/sdk-api';
+
+/**
+ * ---------------------------------------------------------------------------
+ * WHY THIS QUERIES BTC/TBTC ESPLORAS INSTEAD OF AN ECX-SPECIFIC ONE
+ * ---------------------------------------------------------------------------
+ * We are deliberately NOT pointing this at any ecash-com/drivechain esplora
+ * (e.g. drynet3's https://esplora.drynet3.drivechain.dev), even though that
+ * infrastructure exists. Reasoning:
+ *
+ *   1. ECX is a 1:1 hard fork of Bitcoin — every BTC address/UTXO existing at
+ *      the fork block is credited identically on eCash. Pre-fork, "ECX
+ *      history" and "BTC history" are the exact same history: the BTC chain
+ *      itself. So for recovering funds as of today (mainnet hasn't forked
+ *      yet — see ecash-com/fast-facts), the correct and only source of truth
+ *      for UTXO/fee data is the Bitcoin chain, full stop.
+ *   2. There is currently no ECX esplora we trust for production use. The
+ *      only ones that exist are pre-launch dry-run test networks
+ *      (drynet1/2/3) run by a third party ahead of a fork that hasn't
+ *      happened. Pointing prod fund-recovery traffic at that infrastructure
+ *      would mean trusting an unaudited, pre-launch, third-party endpoint
+ *      with real user recovery data for no benefit — the data it would
+ *      return is BTC-identical anyway pre-fork.
+ *
+ * So: prod uses the real Blockstream BTC mainnet esplora, test uses the
+ * Blockstream testnet (tbtc) esplora. This is a deliberate, understood
+ * choice, not an oversight — revisit only once a trusted, launched ECX
+ * esplora exists post-fork (watch drivechain.info/dev.txt).
+ * ---------------------------------------------------------------------------
+ */
+function ecxEsploraCoin(sdk: BitGoAPI): 'btc' | 'tbtc' {
+  return sdk.getEnv() === 'prod' ? 'btc' : 'tbtc';
+}
+
+/**
+ * nLockTime replay-protection marker (drynet3 IsFinalTx scheme).
+ * A tx stamped with nLockTime = 499_999_999 is final on eCash (patched) but
+ * non-final on stock Bitcoin (~500M blocks out), so an ECX sweep cannot
+ * replay onto BTC.  Value defined in the drynet3 branch of ecash-com/bitcoin:
+ * https://github.com/ecash-com/bitcoin/commit/d2dec2fe9bde6787686b9673c00a643d8196c09e
+ * (src/consensus/tx_verify.cpp#L19).  The mobile wallet mirrors this as
+ * `replayProtectionLockHeight` (ecash-com/ecash-wallet-mobile, NetworkRegistry.swift:118).
+ *
+ * BLOCKER: only valid if ECX mainnet ships the drynet3 scheme.  If it ships
+ * the magic-version branch instead, this locktime makes the tx unspendable.
+ */
+const ECX_REPLAY_LOCK_TIME = 499_999_999;
+
+export function createEcxCoin(sdk: BitGoAPI): RecoveryCoin {
+  return {
+    // Always 'btc' here (not env-dependent like the esplora below): ECX
+    // addresses are BTC-mainnet-format regardless of which WRW build the
+    // user is running, so key derivation always uses mainnet params.
+    deriveKeyWithSeed: (key, seed) =>
+      sdk.coin('btc').deriveKeyWithSeed({ key, seed }),
+    // Literal 'tecx', not sdk.coin('btc').getChain() — this is used as the
+    // sweep-file name prefix (BuildUnsignedSweepCoin.tsx), and it would
+    // otherwise write btc-unsigned-sweep-*.json for an ECX recovery.
+    getChain: () => 'tecx',
+
+    async recover(parameters: unknown) {
+      const baseCoin = sdk.coin('btc') as AbstractUtxoCoin;
+      // See the block comment above ecxEsploraCoin() for why this is a
+      // BTC/TBTC esplora rather than anything ECX-specific.
+      const recoveryProvider: RecoveryProvider<number> = BlockstreamApi.forCoin(
+        ecxEsploraCoin(sdk)
+      );
+      const params: RecoverParams = {
+        ...(parameters as RecoverParams),
+        recoveryProvider,
+        lockTime: ECX_REPLAY_LOCK_TIME,
+      };
+      return await baseCoin.recover(params);
+    },
+
+    // ECX unsigned sweeps are written to a file and signed/broadcast outside
+    // WRW (see BuildUnsignedSweepCoin.tsx) — 'tecx' is not in
+    // broadcastTransactionCoins, so this is unreachable from the UI.
+    async broadcast() {
+      throw new Error(
+        'ECX recovery does not support broadcasting through WRW; sign and broadcast the unsigned sweep externally.'
+      );
+    },
+  };
+}

--- a/electron/utxo/index.ts
+++ b/electron/utxo/index.ts
@@ -1,0 +1,4 @@
+export {
+  isNonSdkUtxoCoin,
+  getNonSdkUtxoCoin,
+} from './nonSdkCoins';

--- a/electron/utxo/nonSdkCoins.ts
+++ b/electron/utxo/nonSdkCoins.ts
@@ -1,0 +1,19 @@
+import type { BitGoAPI } from '@bitgo/sdk-api';
+import type { RecoveryCoin } from '../recoveryCoin';
+import { createEcxCoin } from './ecx';
+
+type NonSdkUtxoCoinFactory = (sdk: BitGoAPI) => RecoveryCoin;
+
+const NON_SDK_UTXO_COINS: Record<string, NonSdkUtxoCoinFactory> = {
+  tecx: createEcxCoin,
+};
+
+export function isNonSdkUtxoCoin(coin: string): boolean {
+  return coin in NON_SDK_UTXO_COINS;
+}
+
+export function getNonSdkUtxoCoin(sdk: BitGoAPI, coin: string): RecoveryCoin {
+  const factory = NON_SDK_UTXO_COINS[coin];
+  if (!factory) throw new Error(`not a non-SDK UTXO coin: ${coin}`);
+  return factory(sdk);
+}

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "storybook:preview": "http-server storybook-static --port 6006 --silent",
     "storybook:test": "test-storybook",
     "storybook:test:ci": "build-storybook && concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"http-server storybook-static --port 6006 --silent\" \"wait-on http-get://localhost:6006/ && npx test-storybook\"",
-    "test": "vitest",
+    "test": "NODE_OPTIONS='--experimental-wasm-modules' vitest",
     "bump-bitgo-versions": "npm exec ts-node ./scripts/bump-version"
   },
   "version": "0.0.0-placeholder-version",

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -127,6 +127,7 @@ function Form() {
   switch (coin) {
     case 'btc':
     case 'tbtc':
+    case 'tecx':
       return (
         <BitcoinForm
           key={coin}

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1704,6 +1704,21 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     ApiKeyProvider: 'shadownet.explorer.etherlink.com',
     isTssSupported: true,
   },
+  // WAL-1716 — ECX self-custody recovery via WRW (light path, no new coin).
+  // ECX shares Bitcoin params (bc HRP, coin-type 0', same script types), so the
+  // recovery flow is the BTC path routed through an ECX esplora endpoint with a
+  // replay-protection nLockTime marker. The 'tecx' value is remapped to 'btc'
+  // before sdk.coin(...) — see electron/utxo/ecx.ts for the implementation.
+  //
+  // Only listed in buildUnsignedSweepCoins.test, never .prod: ECX mainnet
+  // hasn't forked yet and this points at the drynet3 pre-launch test network.
+  // Revisit once real mainnet endpoints are published (drivechain.info/dev.txt).
+  tecx: {
+    Title: 'ECX (drynet3 test network)',
+    Description: 'eCash pre-launch test network (self-custody recovery)',
+    Icon: 'btc',
+    value: 'tecx',
+  },
 } as const;
 
 function generateEvmCoinMeta(coin: {
@@ -1884,6 +1899,7 @@ export const buildUnsignedSweepCoins: Record<
   ] as const,
   test: [
     allCoinMetas.tbtc,
+    allCoinMetas.tecx,
     allCoinMetas.txrp,
     allCoinMetas.txrpToken,
     allCoinMetas.txlm,


### PR DESCRIPTION
Add an "ECX" entry to the WRW coin list that routes through the BTC recovery path with an ECX esplora `RecoveryProvider` and an `nLockTime` replay-protection marker (499_999_999). ECX shares Bitcoin params (bc HRP, coin-type `0'`, same script types) so no new coin is registered — the `'ecx'` value is remapped to `'btc'` before every `sdk.coin()` call.

**Changes:**
- `config.ts`: ECX coin metadata + added to `buildUnsignedSweepCoins`
- `BuildUnsignedSweepCoin.tsx`: ECX case reuses `BitcoinForm`
- `electron/main/index.ts`: `EsploraRecoveryProvider`, ECX routing in `recover`/`getChain`/`deriveKeyWithSeed`/`broadcastTransaction` handlers, `nLockTime` marker via temp cast (remove after `@bitgo/abstract-utxo` dep bump)

Refs: WAL-1716
