### PR TITLE
feat(wrw): add ecx recovery alias

### DIFF
--- a/electron/utxo/ecx.test.ts
+++ b/electron/utxo/ecx.test.ts
@@ -32,7 +32,7 @@ const UNSPENT_VALUE = 100_000_000;
 type WasmWalletKeys = ReturnType<typeof buildWalletKeys>;
 
 function buildWalletKeys() {
-  const xpubs = KEYCHAINS.map((k) => BIP32.from(k.pub));
+  const xpubs = KEYCHAINS.map(k => BIP32.from(k.pub));
   return RootWalletKeys.from({
     triple: xpubs,
     derivationPrefixes: ['m/0/0', 'm/0/0', 'm/0/0'],
@@ -53,12 +53,11 @@ function createMockRecoveryProvider(unspentAddress: string): RecoveryProvider {
 
   return {
     async getAddressInfo(a: string) {
-      if (a === unspentAddress)
-        return { txCount: 1, balance: UNSPENT_VALUE };
+      if (a === unspentAddress) return { txCount: 1, balance: UNSPENT_VALUE };
       return { txCount: 0, balance: 0 };
     },
     async getUnspentsForAddresses(addresses: string[]) {
-      return [unspent].filter((u) => addresses.includes(u.address));
+      return [unspent].filter(u => addresses.includes(u.address));
     },
     async getTransactionHex(): Promise<string> {
       throw new Error('not needed for segwit inputs');
@@ -71,7 +70,7 @@ function createMockRecoveryProvider(unspentAddress: string): RecoveryProvider {
 
 function buildRecoverParams(
   walletKeys: WasmWalletKeys,
-  lockTime: number,
+  lockTime: number
 ): RecoverParams {
   const addr = deriveP2wshAddress(walletKeys);
   return {
@@ -104,7 +103,7 @@ describe('createEcxCoin', () => {
       getEnv: vi.fn().mockReturnValue('prod'),
     };
 
-    const ecxCoin = createEcxCoin(mockSdk as any);
+    const ecxCoin = createEcxCoin(mockSdk as any, 'tecx');
 
     await ecxCoin.recover({
       userKey: 'xpub-user',
@@ -114,8 +113,17 @@ describe('createEcxCoin', () => {
     });
 
     expect(mockRecover).toHaveBeenCalledTimes(1);
-    const recoverParams = mockRecover.mock.calls[0][0] as Record<string, unknown>;
+    const recoverParams = mockRecover.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
     expect(recoverParams.lockTime).toBe(ECX_REPLAY_LOCK_TIME);
+  });
+
+  it.each(['ecx', 'tecx'] as const)('uses %s as the chain', chain => {
+    const mockSdk = { coin: vi.fn(), getEnv: vi.fn() };
+
+    expect(createEcxCoin(mockSdk as any, chain).getChain()).toBe(chain);
   });
 });
 
@@ -132,7 +140,7 @@ describe('SDK recover() lockTime sensitivity', () => {
 
   it('encodes lockTime=499_999_999 in the recovered transaction', async () => {
     const result = (await coin.recover(
-      buildRecoverParams(walletKeys, ECX_REPLAY_LOCK_TIME),
+      buildRecoverParams(walletKeys, ECX_REPLAY_LOCK_TIME)
     )) as Record<string, unknown>;
     const hex = extractTxHex(result);
     const tx = Transaction.fromBytes(Buffer.from(hex, 'hex'), COIN_NAME);
@@ -141,7 +149,7 @@ describe('SDK recover() lockTime sensitivity', () => {
 
   it('encodes lockTime=0 when lockTime is set to 0', async () => {
     const result = (await coin.recover(
-      buildRecoverParams(walletKeys, 0),
+      buildRecoverParams(walletKeys, 0)
     )) as Record<string, unknown>;
     const hex = extractTxHex(result);
     const tx = Transaction.fromBytes(Buffer.from(hex, 'hex'), COIN_NAME);
@@ -150,10 +158,10 @@ describe('SDK recover() lockTime sensitivity', () => {
 
   it('produces different transactions for different lockTime values', async () => {
     const resultWithLock = (await coin.recover(
-      buildRecoverParams(walletKeys, ECX_REPLAY_LOCK_TIME),
+      buildRecoverParams(walletKeys, ECX_REPLAY_LOCK_TIME)
     )) as Record<string, unknown>;
     const resultWithoutLock = (await coin.recover(
-      buildRecoverParams(walletKeys, 0),
+      buildRecoverParams(walletKeys, 0)
     )) as Record<string, unknown>;
 
     const hexWithLock = extractTxHex(resultWithLock);

--- a/electron/utxo/ecx.ts
+++ b/electron/utxo/ecx.ts
@@ -53,17 +53,19 @@ function ecxEsploraCoin(sdk: BitGoAPI): 'btc' | 'tbtc' {
  */
 const ECX_REPLAY_LOCK_TIME = 499_999_999;
 
-export function createEcxCoin(sdk: BitGoAPI): RecoveryCoin {
+export function createEcxCoin(
+  sdk: BitGoAPI,
+  chain: 'ecx' | 'tecx'
+): RecoveryCoin {
   return {
     // Always 'btc' here (not env-dependent like the esplora below): ECX
     // addresses are BTC-mainnet-format regardless of which WRW build the
     // user is running, so key derivation always uses mainnet params.
     deriveKeyWithSeed: (key, seed) =>
       sdk.coin('btc').deriveKeyWithSeed({ key, seed }),
-    // Literal 'tecx', not sdk.coin('btc').getChain() — this is used as the
-    // sweep-file name prefix (BuildUnsignedSweepCoin.tsx), and it would
-    // otherwise write btc-unsigned-sweep-*.json for an ECX recovery.
-    getChain: () => 'tecx',
+    // Use the selected network name as the sweep-file prefix rather than
+    // sdk.coin('btc').getChain(), which would write a BTC filename.
+    getChain: () => chain,
 
     async recover(parameters: unknown) {
       const baseCoin = sdk.coin('btc') as AbstractUtxoCoin;
@@ -81,7 +83,7 @@ export function createEcxCoin(sdk: BitGoAPI): RecoveryCoin {
     },
 
     // ECX unsigned sweeps are written to a file and signed/broadcast outside
-    // WRW (see BuildUnsignedSweepCoin.tsx) — 'tecx' is not in
+    // WRW (see BuildUnsignedSweepCoin.tsx) — neither ECX alias is in
     // broadcastTransactionCoins, so this is unreachable from the UI.
     broadcast() {
       throw new Error(

--- a/electron/utxo/nonSdkCoins.ts
+++ b/electron/utxo/nonSdkCoins.ts
@@ -5,7 +5,8 @@ import { createEcxCoin } from './ecx';
 type NonSdkUtxoCoinFactory = (sdk: BitGoAPI) => RecoveryCoin;
 
 const NON_SDK_UTXO_COINS: Record<string, NonSdkUtxoCoinFactory> = {
-  tecx: createEcxCoin,
+  ecx: sdk => createEcxCoin(sdk, 'ecx'),
+  tecx: sdk => createEcxCoin(sdk, 'tecx'),
 };
 
 export function isNonSdkUtxoCoin(coin: string): boolean {

--- a/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/BuildUnsignedSweepCoin.tsx
@@ -127,6 +127,7 @@ function Form() {
   switch (coin) {
     case 'btc':
     case 'tbtc':
+    case 'ecx':
     case 'tecx':
       return (
         <BitcoinForm

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -419,7 +419,8 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
   },
   solNestedATA: {
     Title: 'SOL Nested ATA',
-    Description: 'Recover tokens stuck in a Solana nested Associated Token Account',
+    Description:
+      'Recover tokens stuck in a Solana nested Associated Token Account',
     Icon: 'sol',
     value: 'solNestedATA',
   },
@@ -925,7 +926,8 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
   },
   tsolNestedATA: {
     Title: 'TSOL Nested ATA',
-    Description: 'Recover tokens stuck in a Solana nested Associated Token Account (Testnet)',
+    Description:
+      'Recover tokens stuck in a Solana nested Associated Token Account (Testnet)',
     Icon: 'sol',
     value: 'tsolNestedATA',
   },
@@ -1707,12 +1709,17 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
   // WAL-1716 — ECX self-custody recovery via WRW (light path, no new coin).
   // ECX shares Bitcoin params (bc HRP, coin-type 0', same script types), so the
   // recovery flow is the BTC path routed through an ECX esplora endpoint with a
-  // replay-protection nLockTime marker. The 'tecx' value is remapped to 'btc'
+  // replay-protection nLockTime marker. Both values are remapped to 'btc'
   // before sdk.coin(...) — see electron/utxo/ecx.ts for the implementation.
   //
-  // Only listed in buildUnsignedSweepCoins.test, never .prod: ECX mainnet
-  // hasn't forked yet and this points at the drynet3 pre-launch test network.
-  // Revisit once real mainnet endpoints are published (drivechain.info/dev.txt).
+  // The mainnet and testnet aliases share the ECX recovery implementation.
+  // Revisit the provider choice once a trusted, launched ECX esplora exists.
+  ecx: {
+    Title: 'ECX',
+    Description: 'eCash mainnet (self-custody recovery)',
+    Icon: 'btc',
+    value: 'ecx',
+  },
   tecx: {
     Title: 'ECX (drynet3 test network)',
     Description: 'eCash pre-launch test network (self-custody recovery)',
@@ -1758,8 +1765,12 @@ coins.forEach(coin => {
 
   const name = coin.name;
   const isTestnet = coin.network.type === NetworkType.TESTNET;
-  const hasUnsignedSweep = coin.features.includes(CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY);
-  const hasNonBitgo = coin.features.includes(CoinFeature.EVM_NON_BITGO_RECOVERY);
+  const hasUnsignedSweep = coin.features.includes(
+    CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY
+  );
+  const hasNonBitgo = coin.features.includes(
+    CoinFeature.EVM_NON_BITGO_RECOVERY
+  );
 
   if (!hasUnsignedSweep && !hasNonBitgo) return;
 
@@ -1813,6 +1824,7 @@ export const buildUnsignedSweepCoins: Record<
 > = {
   prod: [
     allCoinMetas.btc,
+    allCoinMetas.ecx,
     allCoinMetas.bch,
     allCoinMetas.ltc,
     allCoinMetas.xrp,


### PR DESCRIPTION
Expose the ECX mainnet identifier alongside the existing testnet alias while
keeping both networks on the shared BTC-backed recovery implementation. Pass
the selected alias through to sweep output naming so mainnet recoveries use
`ecx` instead of the testnet `tecx` prefix.