### PR TITLE
fix(wrw): point Sui recover at live JSON-RPC nodes

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -97,6 +97,9 @@ import { CoinFeature, coins } from '@bitgo/statics';
 import { Xtz, Txtz } from '@bitgo/sdk-coin-xtz';
 import { Ton, Tton, JettonToken } from '@bitgo/sdk-coin-ton';
 import { Tempo, Tip20Token } from '@bitgo/sdk-coin-tempo';
+import { applySuiNodeUrls } from './suiNodeUrl';
+
+applySuiNodeUrls();
 
 const bip32 = BIP32Factory(ecc);
 

--- a/electron/main/suiNodeUrl.ts
+++ b/electron/main/suiNodeUrl.ts
@@ -1,0 +1,15 @@
+import { Environments } from '@bitgo/sdk-core';
+
+/**
+ * Sui Foundation disabled JSON-RPC on fullnode.*.sui.io (week of 27 Jul 2026).
+ * WRW recover only uses BitGo env `test` | `prod`.
+ */
+export const SUI_JSON_RPC_TESTNET = 'https://sui-testnet-rpc.publicnode.com';
+export const SUI_JSON_RPC_MAINNET = 'https://sui-rpc.publicnode.com';
+
+export function applySuiNodeUrls(
+  environments: typeof Environments = Environments
+): void {
+  environments.test.suiNodeUrl = SUI_JSON_RPC_TESTNET;
+  environments.prod.suiNodeUrl = SUI_JSON_RPC_MAINNET;
+}

--- a/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.test.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/NonBitGoRecoveryCoin.test.tsx
@@ -3,7 +3,13 @@ import { FormikHelpers } from 'formik';
 import type { Dispatch, SetStateAction } from 'react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Environments } from '@bitgo/sdk-core';
 import { AlertBannerContext } from '~/contexts';
+import {
+  applySuiNodeUrls,
+  SUI_JSON_RPC_MAINNET,
+  SUI_JSON_RPC_TESTNET,
+} from '../../../electron/main/suiNodeUrl';
 import { NonBitGoRecoveryCoin } from './NonBitGoRecoveryCoin';
 import type { UtxoFormProps, UtxoFormValues } from './UtxoForm';
 
@@ -110,5 +116,19 @@ describe('NonBitGoRecoveryCoin PSBT recovery', () => {
       JSON.stringify({ txHex }, null, 2),
       { encoding: 'utf-8' }
     );
+  });
+});
+
+describe('Sui recover RPC URLs', () => {
+  it('points test and prod at live JSON-RPC nodes', () => {
+    const environments = {
+      test: { suiNodeUrl: 'https://fullnode.testnet.sui.io' },
+      prod: { suiNodeUrl: 'https://fullnode.mainnet.sui.io' },
+    } as Environments;
+
+    applySuiNodeUrls(environments);
+
+    expect(environments.test.suiNodeUrl).toBe(SUI_JSON_RPC_TESTNET);
+    expect(environments.prod.suiNodeUrl).toBe(SUI_JSON_RPC_MAINNET);
   });
 });


### PR DESCRIPTION
## Summary

Override WRW Sui `suiNodeUrl` for `test` and `prod` so Non-BitGo recover hits live JSON-RPC nodes after Sui Foundation disabled JSON-RPC on `fullnode.*.sui.io`.

**Linear**: [WCI-1455](https://linear.app/bitgo/issue/WCI-1455)

## Changes

- Set `Environments.test.suiNodeUrl` to PublicNode testnet and `Environments.prod.suiNodeUrl` to PublicNode mainnet at Electron startup
- Cover the two WRW env URLs in the existing Non-BitGo recovery test file

## Test Plan

- [x] Unit: `applySuiNodeUrls` sets test/prod URLs (existing `NonBitGoRecoveryCoin.test.tsx`)
- [ ] WRW Non-BitGo recover TSUI with start `0` / scan `20` on a funded test wallet
- [ ] Confirm recover JSON `scanIndex` and broadcast
- [ ] Repeat with `startingScanIndex = scanIndex + 1` for a second receive address


Made with [Cursor](https://cursor.com)