### PR TITLE
test(wrw): cover PSBT recovery signing

### DIFF
--- a/e2e/utxo/psbt-encrypted-recovery.spec.ts
+++ b/e2e/utxo/psbt-encrypted-recovery.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { encrypt } from '@bitgo/sdk-api';
+import { BIP32, fixedScriptWallet, Transaction } from '@bitgo/wasm-utxo';
+import { launchApp } from './helpers';
+
+const { BitGoPsbt, ChainCode, RootWalletKeys } = fixedScriptWallet;
+const WALLET_PASSPHRASE = 'psbt-integration-passphrase';
+const RECOVERY_DESTINATION = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+
+function buildUnsignedPsbt(
+  userKey: BIP32,
+  backupKey: BIP32,
+  bitgoKey: BIP32
+): string {
+  const walletKeys = RootWalletKeys.from({
+    triple: [userKey, backupKey, bitgoKey],
+    derivationPrefixes: ['m/0/0', 'm/0/0', 'm/0/0'],
+  });
+  const psbt = BitGoPsbt.createEmpty('tbtc', walletKeys, {
+    version: 2,
+    lockTime: 0,
+  });
+
+  psbt.addWalletInput(
+    { txid: 'ab'.repeat(32), vout: 0, value: BigInt(100_000) },
+    walletKeys,
+    {
+      scriptId: { chain: ChainCode.value('p2wsh', 'external'), index: 0 },
+      signPath: { signer: 'user', cosigner: 'bitgo' },
+    }
+  );
+  psbt.addOutput(RECOVERY_DESTINATION, BigInt(90_000));
+
+  return Buffer.from(psbt.serialize()).toString('base64');
+}
+
+async function buildFixture() {
+  const userKey = BIP32.fromSeedSha256('encrypted-recovery.0');
+  const backupKey = BIP32.fromSeedSha256('encrypted-recovery.1');
+  const bitgoKey = BIP32.fromSeedSha256('encrypted-recovery.2');
+
+  return {
+    backupKey: await encrypt(WALLET_PASSPHRASE, backupKey.toBase58(), {
+      encryptionVersion: 1,
+    }),
+    bitgoKey: bitgoKey.neutered().toBase58(),
+    psbt: buildUnsignedPsbt(userKey, backupKey, bitgoKey),
+    userKey: await encrypt(WALLET_PASSPHRASE, userKey.toBase58(), {
+      encryptionVersion: 1,
+    }),
+  };
+}
+
+function stubUiHandlers(app: ElectronApplication) {
+  return app.evaluate(({ ipcMain }) => {
+    for (const channel of [
+      'setBitGoEnvironment',
+      'showSaveDialog',
+      'writeFile',
+      'broadcastTransaction',
+    ]) {
+      ipcMain.removeHandler(channel);
+    }
+
+    ipcMain.handle('setBitGoEnvironment', () => undefined);
+    ipcMain.handle('showSaveDialog', () => ({
+      filePath: '/tmp/test-encrypted-psbt-recovery.json',
+      canceled: false,
+    }));
+    ipcMain.handle('writeFile', () => undefined);
+    ipcMain.handle('broadcastTransaction', () => {
+      throw new Error('Broadcast must not be called by this test');
+    });
+  });
+}
+
+test.describe('UTXO PSBT recovery with encrypted generated keys', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeEach(async () => {
+    ({ app, page } = await launchApp());
+    await stubUiHandlers(app);
+  });
+
+  test.afterEach(async () => {
+    await app.close();
+  });
+
+  test('decrypts both keys and generates a fully signed transaction', async () => {
+    const fixture = await buildFixture();
+
+    await page.evaluate(() => {
+      window.location.hash = '/test/non-bitgo-recovery/tbtc';
+    });
+    await page.waitForSelector('[name="recoverySource"]');
+    await page.selectOption('[name="recoverySource"]', 'psbt');
+    await page.waitForSelector('[name="psbt"]');
+    await page.fill('[name="userKey"]', fixture.userKey);
+    await page.fill('[name="backupKey"]', fixture.backupKey);
+    await page.fill('[name="bitgoKey"]', fixture.bitgoKey);
+    await page.fill('[name="walletPassphrase"]', WALLET_PASSPHRASE);
+    await page.fill('[name="psbt"]', fixture.psbt);
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL(/non-bitgo-recovery\/tbtc\/success/, {
+      timeout: 10_000,
+    });
+    await expect(page.getByText('We recommend')).toBeVisible();
+    await page.getByText('Show transaction hex').click();
+
+    const transactionHex = await page
+      .getByLabel('Transaction Hex')
+      .inputValue();
+    const transaction = Transaction.fromBytes(
+      Buffer.from(transactionHex, 'hex'),
+      'tbtc'
+    );
+    const witness = transaction.getInputs()[0]?.witness ?? [];
+
+    expect(transaction.getInputs()).toHaveLength(1);
+    expect(transaction.getOutputs()).toHaveLength(1);
+    expect(witness).toHaveLength(4);
+    expect(witness.slice(0, -1).filter(item => item.length > 0)).toHaveLength(
+      2
+    );
+  });
+});

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -665,7 +665,7 @@ async function createWindow() {
       : await sdk.decrypt({ password: params.walletPassphrase, input: params.backupKey });
 
     const psbtHex = psbtToHex(params.psbt);
-    return signPsbtWithBothKeys(baseCoin, psbtHex, userXprv, backupXprv);
+    return signPsbtWithBothKeys(baseCoin, psbtHex, userXprv, backupXprv, params.bitgoKey);
   });
 
   ipcMain.handle('signPsbt', async (_event, coin: string, params: SignPsbtParams) => {

--- a/electron/utxo/psbt.test.ts
+++ b/electron/utxo/psbt.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import { BitGoAPI } from '@bitgo/sdk-api';
+import { Btc } from '@bitgo/sdk-coin-btc';
+import { BIP32, Transaction, fixedScriptWallet } from '@bitgo/wasm-utxo';
+import type { AbstractUtxoCoin } from '@bitgo/abstract-utxo';
+import type { CoinConstructor } from '@bitgo/sdk-core';
+import { signPsbtWithBothKeys } from './psbt';
+
+const INPUT_VALUE = 100_000_000n;
+const OUTPUT_VALUE = 99_900_000n;
+const RECOVERY_DESTINATION = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const { ChainCode, RootWalletKeys } = fixedScriptWallet;
+const btcCoinConstructor: CoinConstructor = bitgo => Btc.createInstance(bitgo);
+const userKey = BIP32.fromSeedSha256('psbt-signing.0');
+const backupKey = BIP32.fromSeedSha256('psbt-signing.1');
+const bitgoKey = BIP32.fromSeedSha256('psbt-signing.2');
+
+function createUnsignedPsbt(): string {
+  const walletKeys = RootWalletKeys.from({
+    triple: [userKey, backupKey, bitgoKey],
+    derivationPrefixes: ['m/0/0', 'm/0/0', 'm/0/0'],
+  });
+  const psbt = fixedScriptWallet.BitGoPsbt.createEmpty('btc', walletKeys, {
+    version: 2,
+    lockTime: 0,
+  });
+
+  psbt.addWalletInput(
+    { txid: 'ab'.repeat(32), vout: 0, value: INPUT_VALUE },
+    walletKeys,
+    {
+      scriptId: { chain: ChainCode.value('p2wsh', 'external'), index: 0 },
+      signPath: { signer: 'user', cosigner: 'bitgo' },
+    }
+  );
+  psbt.addOutput(RECOVERY_DESTINATION, OUTPUT_VALUE);
+
+  return Buffer.from(psbt.serialize()).toString('hex');
+}
+
+describe('signPsbtWithBothKeys', () => {
+  it('produces a finalized transaction with user and backup signatures', async () => {
+    const sdk = new BitGoAPI({ env: 'test' });
+    sdk.register('btc', btcCoinConstructor);
+    const coin = sdk.coin('btc') as AbstractUtxoCoin;
+    const signTransactionSpy = vi.spyOn(coin, 'signTransaction');
+
+    const result = await signPsbtWithBothKeys(
+      coin,
+      createUnsignedPsbt(),
+      userKey.toBase58(),
+      backupKey.toBase58(),
+      bitgoKey.neutered().toBase58()
+    );
+    const transaction = Transaction.fromBytes(
+      Buffer.from(result.txHex, 'hex'),
+      'btc'
+    );
+    const witness = transaction.getInputs()[0]?.witness ?? [];
+
+    expect(transaction.getInputs()).toHaveLength(1);
+    expect(transaction.getOutputs()).toHaveLength(1);
+    expect(witness).toHaveLength(4);
+    expect(witness.slice(0, -1).filter(item => item.length > 0)).toHaveLength(
+      2
+    );
+    const expectedPubs = [
+      userKey.neutered().toBase58(),
+      backupKey.neutered().toBase58(),
+      bitgoKey.neutered().toBase58(),
+    ];
+    expect(
+      signTransactionSpy.mock.calls.map(([params]) => params.pubs)
+    ).toEqual([expectedPubs, expectedPubs]);
+  });
+});

--- a/electron/utxo/psbt.ts
+++ b/electron/utxo/psbt.ts
@@ -83,11 +83,19 @@ export async function signPsbtWithBothKeys(
   psbtHex: string,
   userXprv: string,
   backupXprv: string,
+  bitgoXpub: string,
 ): Promise<{ txHex: string }> {
+  const pubs: [string, string, string] = [
+    BIP32.fromBase58(userXprv).neutered().toBase58(),
+    BIP32.fromBase58(backupXprv).neutered().toBase58(),
+    BIP32.fromBase58(bitgoXpub).toBase58(),
+  ];
+
   const half = await coin.signTransaction({
     txPrebuild: { txHex: psbtHex },
     prv: userXprv,
     isLastSignature: false,
+    pubs,
   });
   const halfHex = extractTxHex(half);
 
@@ -95,6 +103,7 @@ export async function signPsbtWithBothKeys(
     txPrebuild: { txHex: halfHex },
     prv: backupXprv,
     isLastSignature: true,
+    pubs,
   });
   return { txHex: extractTxHex(full) };
 }


### PR DESCRIPTION
Exercise the SDK-backed two-key UTXO signing flow and verify that the
resulting transaction is finalized with both wallet signatures.
