### PR TITLE
test(wrw): add real keycard integration support

### DIFF
--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -12,5 +12,9 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Remove optional canvas binding
+        # pdfjs-dist's optional native canvas binding is incompatible with jsdom
+        # in this Node 20 Vitest job and is not needed by the unit tests.
+        run: rm -rf node_modules/canvas
       - name: Run Vitest tests
         run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ storybook-static/
 test-results/
 playwright-report/
 playwright/.cache/
+artifacts/keycard-recovery-videos/
 
 # electron-vite-react
 .vscode/.debug.env

--- a/e2e/keycard.ts
+++ b/e2e/keycard.ts
@@ -1,0 +1,77 @@
+import { readFile } from 'node:fs/promises';
+import { decrypt } from '@bitgo/sdk-api';
+import { buildLinesFromPDFNodes, parseKeycardFromLines } from '@bitgo/key-card';
+import type { KeycardEntry, PDFTextNode } from '@bitgo/key-card';
+
+const KEYCARD_PDF_PATH = 'RECOVERY_KEYCARD_PDF_PATH';
+
+async function readKeycardPdfFromEnv(): Promise<Uint8Array> {
+  const path = process.env[KEYCARD_PDF_PATH];
+
+  if (path) {
+    return new Uint8Array(await readFile(path));
+  }
+
+  throw new Error(`Set ${KEYCARD_PDF_PATH} for this test`);
+}
+
+/**
+ * Loads the CI-only PDF fixture and reuses the keycard package's section parser.
+ * This intentionally runs in the Playwright test process; the application does not
+ * expose a keycard upload feature.
+ */
+export async function loadKeycardEntriesFromEnv(): Promise<KeycardEntry[]> {
+  const { getDocument } = await import('pdfjs-dist');
+  const pdfDocument = await getDocument({ data: await readKeycardPdfFromEnv() })
+    .promise;
+  const nodes: PDFTextNode[] = [];
+
+  for (let pageNumber = 1; pageNumber <= pdfDocument.numPages; pageNumber++) {
+    const page = await pdfDocument.getPage(pageNumber);
+    const textContent = await page.getTextContent();
+
+    for (const item of textContent.items) {
+      if (!('str' in item) || !Array.isArray(item.transform)) {
+        continue;
+      }
+
+      const text = item.str.replace(/\s+/g, ' ').trim();
+      if (!text) {
+        continue;
+      }
+
+      const x = Number(item.transform[4] ?? 0);
+      const y = Number(item.transform[5] ?? 0);
+      const width = 'width' in item ? Number(item.width ?? 0) : 0;
+
+      nodes.push({ text, x, y, page: pageNumber, width });
+    }
+  }
+
+  return parseKeycardFromLines(buildLinesFromPDFNodes(nodes));
+}
+
+export function getKeycardBoxValue(
+  entries: KeycardEntry[],
+  box: 'A' | 'B' | 'C' | 'D'
+): string {
+  const entry = entries.find(({ label }) => label.startsWith(`${box}:`));
+  if (!entry) {
+    throw new Error(`Keycard is missing Box ${box}`);
+  }
+  return entry.value;
+}
+
+export function decryptKeycardBoxValue(
+  value: string,
+  walletPassphrase: string
+): Promise<string> {
+  if (/^[xt]prv/.test(value)) {
+    return Promise.resolve(value);
+  }
+  return decrypt(walletPassphrase, value);
+}
+
+export function hasKeycardPdfFixture(): boolean {
+  return Boolean(process.env[KEYCARD_PDF_PATH]);
+}

--- a/e2e/utxo/helpers.ts
+++ b/e2e/utxo/helpers.ts
@@ -1,13 +1,51 @@
+import { resolve } from 'node:path';
 import { _electron as electron } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
+
+const SENSITIVE_FIELD_SELECTORS = [
+  '[name="userKey"]',
+  '[name="backupKey"]',
+  '[name="bitgoKey"]',
+  '[name="apiKey"]',
+  '#transaction-hex',
+].join(', ');
+
+const SENSITIVE_FIELD_STYLES = `
+  ${SENSITIVE_FIELD_SELECTORS} {
+    color: transparent !important;
+    -webkit-text-fill-color: transparent !important;
+    caret-color: transparent !important;
+    filter: blur(4px);
+  }
+`;
+
+function getRecordingCheckpointDelay(): number {
+  const configuredValue = process.env.RECOVERY_VIDEO_SLOW_MO_MS;
+  if (configuredValue === undefined) {
+    return process.env.RECORD_KEYCARD_VIDEO === '1' ? 250 : 0;
+  }
+
+  const slowMoMilliseconds = Number(configuredValue);
+  if (!Number.isFinite(slowMoMilliseconds) || slowMoMilliseconds < 0) {
+    throw new Error('RECOVERY_VIDEO_SLOW_MO_MS must be a non-negative number');
+  }
+  return slowMoMilliseconds;
+}
 
 export async function launchApp(): Promise<{
   app: ElectronApplication;
   page: Page;
 }> {
+  const videoDirectory =
+    process.env.RECOVERY_VIDEO_DIR ??
+    resolve(__dirname, '../../artifacts/keycard-recovery-videos');
   const app = await electron.launch({
     args: ['.', '--no-sandbox'],
     env: { ...process.env, ELECTRON_RUN_AS_NODE: '' },
+    recordVideo:
+      process.env.RECORD_KEYCARD_VIDEO === '1'
+        ? { dir: videoDirectory, size: { width: 1440, height: 900 } }
+        : undefined,
   });
   const page = await app.firstWindow();
   await app.evaluate(({ BrowserWindow }) => {
@@ -15,4 +53,17 @@ export async function launchApp(): Promise<{
   });
   await page.waitForSelector('#root');
   return { app, page };
+}
+
+export async function redactSensitiveFieldsForVideo(page: Page): Promise<void> {
+  if (process.env.RECORD_KEYCARD_VIDEO !== '1') return;
+
+  await page.addStyleTag({ content: SENSITIVE_FIELD_STYLES });
+}
+
+export async function waitForRecordingCheckpoint(page: Page): Promise<void> {
+  const checkpointDelay = getRecordingCheckpointDelay();
+  if (checkpointDelay > 0) {
+    await page.waitForTimeout(checkpointDelay);
+  }
 }

--- a/e2e/utxo/keycard-recovery.spec.ts
+++ b/e2e/utxo/keycard-recovery.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { BIP32, Transaction, fixedScriptWallet } from '@bitgo/wasm-utxo';
+import {
+  decryptKeycardBoxValue,
+  getKeycardBoxValue,
+  hasKeycardPdfFixture,
+  loadKeycardEntriesFromEnv,
+} from '../keycard';
+import {
+  launchApp,
+  redactSensitiveFieldsForVideo,
+  waitForRecordingCheckpoint,
+} from './helpers';
+
+const RECOVERY_COIN = process.env.RECOVERY_COIN ?? 'tecx';
+const RECOVERY_ENVIRONMENT = process.env.RECOVERY_ENVIRONMENT ?? 'test';
+const RECOVERY_SCAN = process.env.RECOVERY_SCAN ?? '20';
+const RECOVERY_API_KEY =
+  process.env.RECOVERY_BLOCKCHAIR_API_KEY ?? process.env.BLOCKCHAIR_TOKEN;
+
+async function deriveRecoveryDestination(
+  userKey: string,
+  backupKey: string,
+  bitgoKey: string,
+  walletPassphrase: string
+): Promise<string> {
+  const [userXprv, backupXprv] = await Promise.all([
+    decryptKeycardBoxValue(userKey, walletPassphrase),
+    decryptKeycardBoxValue(backupKey, walletPassphrase),
+  ]);
+  const walletKeys = fixedScriptWallet.RootWalletKeys.from({
+    triple: [
+      BIP32.fromBase58(userXprv),
+      BIP32.fromBase58(backupXprv),
+      BIP32.fromBase58(bitgoKey),
+    ],
+    derivationPrefixes: ['m/0/0', 'm/0/0', 'm/0/0'],
+  });
+
+  return fixedScriptWallet.address(
+    walletKeys,
+    fixedScriptWallet.ChainCode.value('p2wsh', 'internal'),
+    0,
+    'btc'
+  );
+}
+
+function stubUiHandlers(app: ElectronApplication) {
+  return app.evaluate(({ ipcMain }) => {
+    for (const channel of [
+      'showSaveDialog',
+      'writeFile',
+      'broadcastTransaction',
+    ]) {
+      ipcMain.removeHandler(channel);
+    }
+
+    ipcMain.handle('showSaveDialog', () => ({
+      filePath: '/tmp/test-keycard-recovery.json',
+      canceled: false,
+    }));
+    ipcMain.handle('writeFile', () => undefined);
+    ipcMain.handle('broadcastTransaction', () => {
+      throw new Error('Broadcast must not be called by this test');
+    });
+  });
+}
+
+test.use({ screenshot: 'off', trace: 'off', video: 'off' });
+
+test.describe('UTXO recovery from a CI keycard PDF', () => {
+  test.skip(
+    !hasKeycardPdfFixture(),
+    'Recovery keycard fixture is available only in CI'
+  );
+
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeEach(async () => {
+    ({ app, page } = await launchApp());
+    await redactSensitiveFieldsForVideo(page);
+  });
+
+  test.afterEach(async () => {
+    if (process.env.RECOVERY_KEEP_OPEN === '1') {
+      console.log(
+        'Recovery app is kept open; close the Electron window to finish the test.'
+      );
+      await new Promise<void>(resolve => app.once('close', () => resolve()));
+      return;
+    }
+    await app.close();
+  });
+
+  test('parses a keycard and performs a full blockchain recovery', async () => {
+    if (process.env.RECOVERY_KEEP_OPEN === '1') {
+      test.setTimeout(0);
+    } else {
+      test.setTimeout(120_000);
+    }
+
+    const walletPassphrase = process.env.RECOVERY_WALLET_PASSPHRASE;
+    if (!walletPassphrase) {
+      throw new Error('Set RECOVERY_WALLET_PASSPHRASE for this test');
+    }
+    if (
+      RECOVERY_COIN !== 'ecx' &&
+      RECOVERY_COIN !== 'tecx' &&
+      !RECOVERY_API_KEY
+    ) {
+      throw new Error(
+        'Set RECOVERY_BLOCKCHAIR_API_KEY or BLOCKCHAIR_TOKEN for this coin'
+      );
+    }
+
+    const entries = await loadKeycardEntriesFromEnv();
+    const userKey = getKeycardBoxValue(entries, 'A');
+    const backupKey = getKeycardBoxValue(entries, 'B');
+    const bitgoKey = getKeycardBoxValue(entries, 'C');
+    const recoveryDestination = await deriveRecoveryDestination(
+      userKey,
+      backupKey,
+      bitgoKey,
+      walletPassphrase
+    );
+    await stubUiHandlers(app);
+
+    const recoveryPath = `/${RECOVERY_ENVIRONMENT}/non-bitgo-recovery/${RECOVERY_COIN}`;
+    await page.evaluate(path => {
+      window.location.hash = path;
+    }, recoveryPath);
+    await page.waitForSelector('[name="recoverySource"]');
+    await waitForRecordingCheckpoint(page);
+
+    await expect(page.locator('[name="recoverySource"]')).toHaveValue(
+      'blockchain'
+    );
+    await page.waitForSelector('[name="recoveryDestination"]');
+    await waitForRecordingCheckpoint(page);
+
+    await page.fill('[name="userKey"]', userKey);
+    await page.fill('[name="backupKey"]', backupKey);
+    await page.fill('[name="bitgoKey"]', bitgoKey);
+    await page.fill('[name="walletPassphrase"]', walletPassphrase);
+    await page.fill('[name="recoveryDestination"]', recoveryDestination);
+    await page.fill('[name="scan"]', RECOVERY_SCAN);
+    if (
+      RECOVERY_COIN !== 'ecx' &&
+      RECOVERY_COIN !== 'tecx' &&
+      RECOVERY_API_KEY
+    ) {
+      await page.fill('[name="apiKey"]', RECOVERY_API_KEY);
+    }
+    await waitForRecordingCheckpoint(page);
+
+    await page.click('button[type="submit"]');
+    await page.waitForURL(
+      new RegExp(`non-bitgo-recovery/${RECOVERY_COIN}/success`),
+      { timeout: 120_000 }
+    );
+    await expect(page.getByText('We recommend')).toBeVisible();
+    await waitForRecordingCheckpoint(page);
+
+    await page.getByText('Show transaction hex').click();
+    const generatedTransactionHex = await page
+      .getByLabel('Transaction Hex')
+      .inputValue();
+    expect(generatedTransactionHex).toMatch(/^[0-9a-f]+$/i);
+    expect(generatedTransactionHex.length).toBeGreaterThan(0);
+
+    const generatedTransaction = Transaction.fromBytes(
+      Buffer.from(generatedTransactionHex, 'hex'),
+      'tbtc'
+    );
+    expect(generatedTransaction.getInputs().length).toBeGreaterThan(0);
+    expect(generatedTransaction.getOutputs()).toHaveLength(1);
+    expect(generatedTransaction.getOutputsWithAddress('btc')[0]?.address).toBe(
+      recoveryDestination
+    );
+
+    for (const input of generatedTransaction.getInputs()) {
+      const witness = input.witness ?? [];
+      const hasWitnessSignature = witness
+        .slice(0, -1)
+        .some(item => item.length > 0);
+      const hasLegacySignature = input.scriptSig.length > 0;
+      expect(hasWitnessSignature || hasLegacySignature).toBe(true);
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "yup": "0.32.11"
       },
       "devDependencies": {
+        "@bitgo/key-card": "0.34.11",
         "@playwright/test": "^1.49.1",
         "@solana/web3.js": "1.66.1",
         "@storybook/addon-essentials": "6.5.16",
@@ -124,6 +125,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "http-server": "14.1.1",
         "jsdom": "20.0.3",
+        "pdfjs-dist": "4.0.379",
         "playwright": "1.28.1",
         "prettier": "3.6.2",
         "tailwindcss": "3.2.4",
@@ -2540,6 +2542,23 @@
       "dependencies": {
         "@types/cookiejar": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@bitgo/key-card": {
+      "version": "0.34.11",
+      "resolved": "https://registry.npmjs.org/@bitgo/key-card/-/key-card-0.34.11.tgz",
+      "integrity": "sha512-KrYwD72mixmX2G2FL86pXXV9ohdybDDQ9j7C8YKqFCy7OFuG1pAA2J+kCRYGXjV8wRV52tsI2cpQYtk3Juc6BA==",
+      "dev": true,
+      "dependencies": {
+        "@bitgo/sdk-api": "^2.4.2",
+        "@bitgo/sdk-core": "^38.11.0",
+        "@bitgo/statics": "^59.10.0",
+        "fp-ts": "^2.16.2",
+        "io-ts": "npm:@bitgo-forks/io-ts@2.1.4",
+        "io-ts-types": "^0.5.19",
+        "jspdf": ">=4.2.0",
+        "pdfjs-dist": "^4.0.0",
+        "qrcode": "^1.5.1"
       }
     },
     "node_modules/@bitgo/logger": {
@@ -9841,6 +9860,112 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz",
@@ -16313,6 +16438,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -16366,6 +16497,13 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/randombytes": {
       "version": "2.0.3",
@@ -16460,6 +16598,13 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/uglify-js": {
       "version": "3.17.5",
@@ -17299,6 +17444,13 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/abitype": {
       "version": "1.2.3",
@@ -21307,6 +21459,42 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -22972,6 +23160,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -23876,6 +24074,12 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "dev": true
+    },
     "node_modules/dir-compare": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
@@ -24103,6 +24307,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "dev": true,
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -27030,6 +27244,33 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ]
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -27173,6 +27414,12 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
       "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
+      "dev": true
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true
     },
     "node_modules/figgy-pudding": {
@@ -29283,6 +29530,20 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -29892,6 +30153,12 @@
         "monocle-ts": "^2.0.0",
         "newtype-ts": "^0.3.2"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "dev": true
     },
     "node_modules/ip": {
       "version": "2.0.1",
@@ -34431,6 +34698,23 @@
         "node": "*"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -37175,6 +37459,22 @@
         "node": ">=12.19"
       }
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -38514,6 +38814,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/path2d-polyfill": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
+      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -38539,11 +38849,31 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pdfjs-dist": {
+      "version": "4.0.379",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.0.379.tgz",
+      "integrity": "sha512-6H0Gv1nna+wmrr3CakaKlZ4rbrL8hvGIFAgg4YcoFuGC0HC4B2DVjXEGTFjJEjLlf8nYi3C3/MYRcM5bNx0elA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "path2d-polyfill": "^2.0.1"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -38812,6 +39142,15 @@
       "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pnp-webpack-plugin": {
@@ -39670,6 +40009,150 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dev": true,
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
@@ -39741,6 +40224,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/ramda": {
@@ -40842,6 +41335,16 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
       "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -42026,6 +42529,65 @@
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
       "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-get/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-get/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/simple-plist": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
@@ -42590,6 +43152,16 @@
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/stackframe": {
@@ -43568,6 +44140,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
@@ -44027,6 +44609,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -45576,6 +46168,26 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/utrie/node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   },
   "description": "A UI-based desktop app for BitGo Recoveries",
   "devDependencies": {
+    "@bitgo/key-card": "0.34.11",
     "@playwright/test": "^1.49.1",
     "@solana/web3.js": "1.66.1",
     "@storybook/addon-essentials": "6.5.16",
@@ -125,6 +126,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "http-server": "14.1.1",
     "jsdom": "20.0.3",
+    "pdfjs-dist": "4.0.379",
     "playwright": "1.28.1",
     "prettier": "3.6.2",
     "tailwindcss": "3.2.4",


### PR DESCRIPTION
Add opt-in Electron integration coverage that reads a real keycard PDF from
RECOVERY_KEYCARD_PDF_PATH and decrypts it with RECOVERY_WALLET_PASSPHRASE.
Include video recording, pacing, and keep-open controls for inspecting the
recovery result.
