### PR TITLE
fix(wrw): correct grammar in recovery form helper text

### DIFF
--- a/src/containers/BuildUnsignedConsolidation/SolTokenForm.tsx
+++ b/src/containers/BuildUnsignedConsolidation/SolTokenForm.tsx
@@ -163,7 +163,7 @@ export function SolTokenForm({ onSubmit }: SolFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikSelectfield
-            HelperText="The programId for smart contract of the token to recover."
+            HelperText="The programId for the smart contract of the token to recover."
             Label="Token ProgramId"
             name="tokenProgramId"
             Width="fill"

--- a/src/containers/BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx
@@ -113,7 +113,7 @@ export function AvalancheCTokenForm({ onSubmit }: AvalancheCTokenFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikTextfield
-            HelperText="Gas limit for the AVAXC transaction. The value should be between 30,000 and 20,000,000. The default is 500,000 unit of gas."
+            HelperText="Gas limit for the AVAXC transaction. The value should be between 30,000 and 20,000,000. The default is 500,000 units of gas."
             Label="Gas Limit"
             name="gasLimit"
             Width="fill"

--- a/src/containers/BuildUnsignedSweepCoin/EthLikeForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/EthLikeForm.tsx
@@ -122,7 +122,7 @@ export function EthLikeForm({ onSubmit, coinName }: EthLikeFormProps) {
               allCoinMetas[coinName].minGasLimit ?? '30,000'
             } and 20,000,000. The default is ${
               allCoinMetas[coinName].defaultGasLimit ?? '500,000'
-            } unit of gas.`}
+            } units of gas.`}
             Label="Gas Limit"
             name="gasLimit"
             Width="fill"

--- a/src/containers/BuildUnsignedSweepCoin/EthLikeTokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/EthLikeTokenForm.tsx
@@ -125,7 +125,7 @@ export function EthLikeTokenForm({
               allCoinMetas[coinName].minGasLimit ?? '30,000'
             } and 20,000,000. The default is ${
               allCoinMetas[coinName].defaultGasLimit ?? '500,000'
-            } unit of gas.`}
+            } units of gas.`}
             Label="Gas Limit"
             name="gasLimit"
             Width="fill"

--- a/src/containers/BuildUnsignedSweepCoin/EthereumWForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/EthereumWForm.tsx
@@ -101,7 +101,7 @@ export function EthereumWForm({ onSubmit }: EthereumWFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikTextfield
-            HelperText="Gas limit for the ETH transaction. The value should be between 30,000 and 20,000,000. The default is 500,000 unit of gas."
+            HelperText="Gas limit for the ETH transaction. The value should be between 30,000 and 20,000,000. The default is 500,000 units of gas."
             Label="Gas Limit"
             name="gasLimit"
             Width="fill"

--- a/src/containers/BuildUnsignedSweepCoin/SolanaTokenForm.tsx
+++ b/src/containers/BuildUnsignedSweepCoin/SolanaTokenForm.tsx
@@ -112,7 +112,7 @@ export function SolanaTokenForm({ onSubmit }: SolanaTokenFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikSelectfield
-            HelperText="The programId for smart contract of the token to recover."
+            HelperText="The programId for the smart contract of the token to recover."
             Label="Token ProgramId"
             name="tokenProgramId"
             Width="fill"

--- a/src/containers/NonBitGoRecoveryCoin/EthLikeForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/EthLikeForm.tsx
@@ -142,7 +142,7 @@ export function EthereumForm({ onSubmit, coinName }: EthLikeFormProps) {
               allCoinMetas[coinName].minGasLimit ?? '30,000'
             } and 20,000,000. The default is ${
               allCoinMetas[coinName].defaultGasLimit ?? '500,000'
-            } unit of gas.`}
+            } units of gas.`}
             Label="Gas limit"
             name="gasLimit"
             Width="fill"

--- a/src/containers/NonBitGoRecoveryCoin/SolanaTokenForm.tsx
+++ b/src/containers/NonBitGoRecoveryCoin/SolanaTokenForm.tsx
@@ -150,7 +150,7 @@ export function SolanaTokenForm({ onSubmit }: SolanaTokenFormProps) {
         </div>
         <div className="tw-mb-4">
           <FormikSelectfield
-            HelperText="The programId for smart contract of the token to recover."
+            HelperText="The programId for the smart contract of the token to recover."
             Label="Token ProgramId"
             name="tokenProgramId"
             Width="fill"


### PR DESCRIPTION
## Summary

Two grammar fixes in user-facing form helper text (8 occurrences, 8 files). UI copy only - no logic, identifiers or component behaviour changed.

- **`unit of gas.` -> `units of gas.`** (gas-limit helper text): `BuildUnsignedSweepCoin/EthLikeForm.tsx`, `BuildUnsignedSweepCoin/EthLikeTokenForm.tsx`, `BuildUnsignedSweepCoin/EthereumWForm.tsx`, `BuildUnsignedSweepCoin/AvalancheCTokenForm.tsx`, `NonBitGoRecoveryCoin/EthLikeForm.tsx`
- **`The programId for smart contract of the token to recover.` -> `The programId for the smart contract of the token to recover.`**: `NonBitGoRecoveryCoin/SolanaTokenForm.tsx`, `BuildUnsignedSweepCoin/SolanaTokenForm.tsx`, `BuildUnsignedConsolidation/SolTokenForm.tsx`

These are `HelperText` strings rendered in the UI. No test or snapshot in the repo asserts on either string (checked with a repo-wide grep; there is no `__snapshots__` directory).