### PR TITLE
feat(config): replace Story explorer hosts with Data Network

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1187,7 +1187,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'ip',
     value: 'ip',
     isTssSupported: true,
-    ApiKeyProvider: 'storyscan.io',
+    ApiKeyProvider: 'datanetscan.io',
   },
   tip: {
     Title: 'TIP',
@@ -1195,7 +1195,7 @@ export const allCoinMetas: Record<string, CoinMetadata> = {
     Icon: 'ip',
     value: 'tip',
     isTssSupported: true,
-    ApiKeyProvider: 'aeneid.storyscan.io',
+    ApiKeyProvider: 'aeneid.datanetscan.io',
   },
   og: {
     Title: 'OG',


### PR DESCRIPTION
## Summary
- Update `ip` / `tip` ApiKeyProvider hosts from storyscan → datanetscan
- Part of [CECHO-2075](https://linear.app/bitgo/issue/CECHO-2075/replace-rpc-urls-from-storyip-to-data-network) Phase 2

## Test plan
- [ ] Confirm config hosts for ip/tip
- [ ] Smoke recovery/explorer API key path against datanetscan if keys available

Ticket: CECHO-2075

Made with [Cursor](https://cursor.com)